### PR TITLE
feat: add total amount validation and automatic date setting in Donation doctype

### DIFF
--- a/non_profit/non_profit/doctype/donation/donation.js
+++ b/non_profit/non_profit/doctype/donation/donation.js
@@ -8,6 +8,9 @@ frappe.ui.form.on("Donation", {
         frm.events.make_payment_entry(frm);
       });
     }
+    if (!frm.doc.date) {
+      frm.set_value("date", frappe.datetime.get_today());
+    }
   },
 
   make_payment_entry: function (frm) {
@@ -32,7 +35,6 @@ frappe.ui.form.on("Donation Payment Item", {
     if (frm.doc.amount > 0) {
       row.percentage = (row.amount / frm.doc.amount) * 100;
     }
-    update_totals(frm);
     frm.refresh_field("donation_payments");
   },
 
@@ -41,23 +43,6 @@ frappe.ui.form.on("Donation Payment Item", {
     if (frm.doc.amount > 0) {
       row.amount = (row.percentage / 100) * frm.doc.amount;
     }
-    update_totals(frm);
     frm.refresh_field("donation_payments");
   },
 });
-
-function update_totals(frm) {
-  let total_percentage = 0;
-  let total_amount = 0;
-
-  (frm.doc.donation_payments || []).forEach((row) => {
-    total_percentage += parseFloat(row.percentage) || 0;
-    total_amount += parseFloat(row.amount) || 0;
-  });
-
-  if (total_percentage >= 100) {
-    frm.set_value("paid", 1);
-  } else {
-    frm.set_value("paid", 0);
-  }
-}

--- a/non_profit/non_profit/doctype/donation/donation.json
+++ b/non_profit/non_profit/doctype/donation/donation.json
@@ -1,193 +1,204 @@
 {
-  "actions": [],
-  "autoname": "naming_series:",
-  "creation": "2021-02-17 10:28:52.645731",
-  "doctype": "DocType",
-  "editable_grid": 1,
-  "engine": "InnoDB",
-  "field_order": [
-    "naming_series",
-    "donor",
-    "donor_name",
-    "email",
-    "column_break_4",
-    "company",
-    "date",
-    "payment_details_section",
-    "paid",
-    "amount",
-    "mode_of_payment",
-    "column_break_12",
-    "payment_id",
-    "currency",
-    "amount_distributed",
-    "section_break_jgcy",
-    "donation_payments",
-    "amended_from"
-  ],
-  "fields": [
-    {
-      "fieldname": "donor",
-      "fieldtype": "Link",
-      "label": "Donor",
-      "options": "Donor",
-      "reqd": 1
-    },
-    {
-      "fetch_from": "donor.donor_name",
-      "fieldname": "donor_name",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Donor Name",
-      "read_only": 1
-    },
-    {
-      "fetch_from": "donor.email",
-      "fieldname": "email",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Email",
-      "read_only": 1
-    },
-    {
-      "fieldname": "column_break_4",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "date",
-      "fieldtype": "Date",
-      "label": "Date",
-      "reqd": 1
-    },
-    {
-      "fieldname": "payment_details_section",
-      "fieldtype": "Section Break",
-      "label": "Payment Details"
-    },
-    {
-      "fieldname": "amount",
-      "fieldtype": "Currency",
-      "label": "Amount",
-      "reqd": 1
-    },
-    {
-      "fieldname": "mode_of_payment",
-      "fieldtype": "Link",
-      "label": "Mode of Payment",
-      "options": "Mode of Payment"
-    },
-    {
-      "fieldname": "naming_series",
-      "fieldtype": "Select",
-      "label": "Naming Series",
-      "options": "NPO-DTN-.YYYY.-"
-    },
-    {
-      "allow_on_submit": 1,
-      "default": "0",
-      "fieldname": "paid",
-      "fieldtype": "Check",
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Paid"
-    },
-    {
-      "fieldname": "company",
-      "fieldtype": "Link",
-      "label": "Company",
-      "options": "Company",
-      "reqd": 1
-    },
-    {
-      "fieldname": "amended_from",
-      "fieldtype": "Link",
-      "label": "Amended From",
-      "no_copy": 1,
-      "options": "Donation",
-      "print_hide": 1,
-      "read_only": 1
-    },
-    {
-      "fieldname": "payment_id",
-      "fieldtype": "Data",
-      "label": "Payment ID"
-    },
-    {
-      "fieldname": "column_break_12",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "currency",
-      "fieldtype": "Link",
-      "label": "Currency",
-      "options": "Currency"
-    },
-    {
-      "fieldname": "section_break_jgcy",
-      "fieldtype": "Section Break"
-    },
-    {
-      "allow_on_submit": 1,
-      "fieldname": "donation_payments",
-      "fieldtype": "Table",
-      "label": "Donation Payments",
-      "options": "Donation Payment Item"
-    },
-    {
-      "allow_on_submit": 1,
-      "fieldname": "amount_distributed",
-      "fieldtype": "Currency",
-      "ignore_user_permissions": 1,
-      "label": "Amount Distributed",
-      "read_only": 1
-    }
-  ],
-  "index_web_pages_for_search": 1,
-  "is_submittable": 1,
-  "links": [],
-  "modified": "2025-05-15 11:38:10.794896",
-  "modified_by": "Administrator",
-  "module": "Non Profit",
-  "name": "Donation",
-  "naming_rule": "By \"Naming Series\" field",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "select": 1,
-      "share": 1,
-      "submit": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Non Profit Manager",
-      "select": 1,
-      "share": 1,
-      "submit": 1,
-      "write": 1
-    }
-  ],
-  "row_format": "Dynamic",
-  "search_fields": "donor_name, email",
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [],
-  "title_field": "donor_name",
-  "track_changes": 1
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2021-02-17 10:28:52.645731",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "naming_series",
+  "donor",
+  "donor_name",
+  "email",
+  "column_break_4",
+  "company",
+  "date",
+  "payment_details_section",
+  "paid",
+  "amount",
+  "mode_of_payment",
+  "column_break_12",
+  "payment_id",
+  "currency",
+  "amount_distributed",
+  "section_break_jgcy",
+  "donation_payments",
+  "total_amount_paid",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "donor",
+   "fieldtype": "Link",
+   "label": "Donor",
+   "options": "Donor",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "donor.donor_name",
+   "fieldname": "donor_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Donor Name",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "donor.email",
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Email",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "label": "Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "payment_details_section",
+   "fieldtype": "Section Break",
+   "label": "Payment Details"
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "label": "Amount",
+   "reqd": 1
+  },
+  {
+   "fieldname": "mode_of_payment",
+   "fieldtype": "Link",
+   "label": "Mode of Payment",
+   "options": "Mode of Payment"
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Naming Series",
+   "options": "NPO-DTN-.YYYY.-"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "paid",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Paid"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Donation",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "payment_id",
+   "fieldtype": "Data",
+   "label": "Payment ID"
+  },
+  {
+   "fieldname": "column_break_12",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "label": "Currency",
+   "options": "Currency"
+  },
+  {
+   "fieldname": "section_break_jgcy",
+   "fieldtype": "Section Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "donation_payments",
+   "fieldtype": "Table",
+   "label": "Donation Payments",
+   "options": "Donation Payment Item"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "amount_distributed",
+   "fieldtype": "Currency",
+   "ignore_user_permissions": 1,
+   "label": "Amount Distributed",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "total_amount_paid",
+   "fieldtype": "Currency",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Total Amount Paid"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2025-05-16 19:09:57.082469",
+ "modified_by": "Administrator",
+ "module": "Non Profit",
+ "name": "Donation",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "select": 1,
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "select": 1,
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "search_fields": "donor_name, email",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "donor_name",
+ "track_changes": 1
 }

--- a/non_profit/non_profit/doctype/donation/donation.py
+++ b/non_profit/non_profit/doctype/donation/donation.py
@@ -22,6 +22,32 @@ class Donation(Document):
 				self.create_donor_for_website_user()
 			else:
 				frappe.throw(_('Please select a Member'))
+		self.compute_total_and_validate()
+
+	def before_update_after_submit(self):
+		self.compute_total_and_validate()
+
+
+	def compute_total_and_validate(self):
+		donation_payments = self.get("donation_payments") or []
+		total_paid = sum(flt(row.amount) for row in donation_payments)
+		self.total_amount_paid = total_paid
+
+		for row in donation_payments:
+			if flt(self.amount):
+				row.percentage = (flt(row.amount) / flt(self.amount)) * 100
+			else:
+				row.percentage = 0
+
+		total_percentage = sum(flt(row.percentage) for row in donation_payments)
+
+		if total_paid > flt(self.amount):
+			frappe.throw(_('Total amount paid cannot exceed Donation Amount.'))
+
+		if total_percentage >= 100:
+			self.paid = 1
+		else:
+			self.paid = 0
 
 	def create_donor_for_website_user(self):
 		donor_name = frappe.get_value('Donor', dict(email=frappe.session.user))

--- a/non_profit/non_profit/doctype/donation_payment_item/donation_payment_item.json
+++ b/non_profit/non_profit/doctype/donation_payment_item/donation_payment_item.json
@@ -75,7 +75,8 @@
    "in_list_view": 1,
    "in_preview": 1,
    "in_standard_filter": 1,
-   "label": "Payment Date"
+   "label": "Payment Date",
+   "reqd": 1
   },
   {
    "allow_on_submit": 1,
@@ -93,7 +94,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-14 19:59:21.046060",
+ "modified": "2025-05-16 20:51:39.822460",
  "modified_by": "Administrator",
  "module": "Non Profit",
  "name": "Donation Payment Item",

--- a/non_profit/non_profit/doctype/donor/donor.json
+++ b/non_profit/non_profit/doctype/donor/donor.json
@@ -1,181 +1,181 @@
 {
-  "actions": [],
-  "allow_rename": 1,
-  "autoname": "field:email",
-  "creation": "2017-09-19 16:20:27.510196",
-  "doctype": "DocType",
-  "editable_grid": 1,
-  "engine": "InnoDB",
-  "field_order": [
-    "donor_name",
-    "email",
-    "phone_number",
-    "id_number",
-    "salutation",
-    "column_break_5",
-    "donor_type",
-    "charter",
-    "birthday_date",
-    "date_registered",
-    "is_a_frequent_donor",
-    "image",
-    "address_contacts",
-    "address_html",
-    "column_break_9",
-    "contact_html",
-    "accounting_dimensions_section",
-    "cost_center",
-    "dimension_col_break"
-  ],
-  "fields": [
-    {
-      "fieldname": "donor_name",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Donor Name",
-      "reqd": 1
-    },
-    {
-      "fieldname": "column_break_5",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "donor_type",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Donor Type",
-      "options": "Donor Type",
-      "reqd": 1
-    },
-    {
-      "fieldname": "email",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "Email",
-      "reqd": 1,
-      "unique": 1
-    },
-    {
-      "fieldname": "image",
-      "fieldtype": "Attach Image",
-      "hidden": 1,
-      "label": "Image",
-      "no_copy": 1,
-      "print_hide": 1
-    },
-    {
-      "depends_on": "eval:!doc.__islocal;",
-      "fieldname": "address_contacts",
-      "fieldtype": "Section Break",
-      "label": "Address and Contact",
-      "options": "fa fa-map-marker"
-    },
-    {
-      "fieldname": "address_html",
-      "fieldtype": "HTML",
-      "label": "Address HTML"
-    },
-    {
-      "fieldname": "column_break_9",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "contact_html",
-      "fieldtype": "HTML",
-      "label": "Contact HTML"
-    },
-    {
-      "collapsible": 1,
-      "fieldname": "accounting_dimensions_section",
-      "fieldtype": "Section Break",
-      "label": "Accounting Dimensions"
-    },
-    {
-      "fieldname": "cost_center",
-      "fieldtype": "Table MultiSelect",
-      "label": "Cost Center",
-      "options": "Beneficiary Program"
-    },
-    {
-      "fieldname": "dimension_col_break",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "0",
-      "fieldname": "is_a_frequent_donor",
-      "fieldtype": "Check",
-      "label": "Is a frequent donor?"
-    },
-    {
-      "fieldname": "phone_number",
-      "fieldtype": "Data",
-      "label": "Phone Number"
-    },
-    {
-      "fieldname": "birthday_date",
-      "fieldtype": "Date",
-      "label": "Birthday Date"
-    },
-    {
-      "fieldname": "id_number",
-      "fieldtype": "Data",
-      "label": "ID Number"
-    },
-    {
-      "fieldname": "salutation",
-      "fieldtype": "Link",
-      "label": "Salutation",
-      "options": "Salutation"
-    },
-    {
-      "fieldname": "date_registered",
-      "fieldtype": "Date",
-      "label": "Date Registered"
-    },
-    {
-      "fieldname": "charter",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Charter",
-      "options": "Funding Pool"
-    }
-  ],
-  "image_field": "image",
-  "links": [
-    {
-      "link_doctype": "Donation",
-      "link_fieldname": "donor"
-    }
-  ],
-  "modified": "2025-05-15 11:51:22.913705",
-  "modified_by": "Administrator",
-  "module": "Non Profit",
-  "name": "Donor",
-  "naming_rule": "By fieldname",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Non Profit Manager",
-      "share": 1,
-      "write": 1
-    }
-  ],
-  "quick_entry": 1,
-  "restrict_to_domain": "Non Profit",
-  "row_format": "Dynamic",
-  "search_fields": "donor_name,email,phone_number",
-  "show_title_field_in_link": 1,
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [],
-  "title_field": "donor_name",
-  "track_changes": 1,
-  "translated_doctype": 1
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:email",
+ "creation": "2017-09-19 16:20:27.510196",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "donor_name",
+  "email",
+  "phone_number",
+  "id_number",
+  "salutation",
+  "column_break_5",
+  "donor_type",
+  "charter",
+  "birthday_date",
+  "date_registered",
+  "is_a_frequent_donor",
+  "image",
+  "address_contacts",
+  "address_html",
+  "column_break_9",
+  "contact_html",
+  "accounting_dimensions_section",
+  "cost_center",
+  "dimension_col_break"
+ ],
+ "fields": [
+  {
+   "fieldname": "donor_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Donor Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_5",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "donor_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Donor Type",
+   "options": "Donor Type",
+   "reqd": 1
+  },
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Email",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "image",
+   "fieldtype": "Attach Image",
+   "hidden": 1,
+   "label": "Image",
+   "no_copy": 1,
+   "print_hide": 1
+  },
+  {
+   "depends_on": "eval:!doc.__islocal;",
+   "fieldname": "address_contacts",
+   "fieldtype": "Section Break",
+   "label": "Address and Contact",
+   "options": "fa fa-map-marker"
+  },
+  {
+   "fieldname": "address_html",
+   "fieldtype": "HTML",
+   "label": "Address HTML"
+  },
+  {
+   "fieldname": "column_break_9",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "contact_html",
+   "fieldtype": "HTML",
+   "label": "Contact HTML"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "accounting_dimensions_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting Dimensions"
+  },
+  {
+   "fieldname": "cost_center",
+   "fieldtype": "Table MultiSelect",
+   "label": "Cost Center",
+   "options": "Beneficiary Program"
+  },
+  {
+   "fieldname": "dimension_col_break",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_a_frequent_donor",
+   "fieldtype": "Check",
+   "label": "Is a frequent donor?"
+  },
+  {
+   "fieldname": "phone_number",
+   "fieldtype": "Data",
+   "label": "Phone Number"
+  },
+  {
+   "fieldname": "birthday_date",
+   "fieldtype": "Date",
+   "label": "Birthday Date"
+  },
+  {
+   "fieldname": "id_number",
+   "fieldtype": "Data",
+   "label": "ID Number"
+  },
+  {
+   "fieldname": "salutation",
+   "fieldtype": "Link",
+   "label": "Salutation",
+   "options": "Salutation"
+  },
+  {
+   "fieldname": "date_registered",
+   "fieldtype": "Date",
+   "label": "Date Registered"
+  },
+  {
+   "fieldname": "charter",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Charter",
+   "options": "Funding Pool"
+  }
+ ],
+ "image_field": "image",
+ "links": [
+  {
+   "link_doctype": "Donation",
+   "link_fieldname": "donor"
+  }
+ ],
+ "modified": "2025-05-16 19:10:26.476409",
+ "modified_by": "Administrator",
+ "module": "Non Profit",
+ "name": "Donor",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Non Profit Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "restrict_to_domain": "Non Profit",
+ "row_format": "Dynamic",
+ "search_fields": "donor_name,email,phone_number",
+ "show_title_field_in_link": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "donor_name",
+ "track_changes": 1,
+ "translated_doctype": 1
 }


### PR DESCRIPTION
This pull request introduces enhancements and fixes to the `Donation` and `Donation Payment Item` doctypes in the `Non Profit` module. The changes focus on improving data validation, streamlining calculations, and enhancing the user interface by adding new fields and making certain fields mandatory.

### Enhancements to `Donation` Doctype:

* Added logic to automatically set the `date` field to the current date if it is not already populated in `donation.js`.
* Introduced a new field `total_amount_paid` in `donation.json` to track the total amount paid, with configurations to display it in list view, filters, and previews. [[1]](diffhunk://#diff-94dd4bcada91ab1fc6a8027817e472df97fa9413dd3bf1ee749e1c089f9a0286R26) [[2]](diffhunk://#diff-94dd4bcada91ab1fc6a8027817e472df97fa9413dd3bf1ee749e1c089f9a0286R146-R161)
* Implemented a new method `compute_total_and_validate` in `donation.py` to calculate total payments, update percentages, and validate that the total paid does not exceed the donation amount. This method is called during validation and before updates after submission.

### Enhancements to `Donation Payment Item` Doctype:

* Made the `Payment Date` field mandatory in `donation_payment_item.json` to ensure completeness of payment records.

### Code Cleanup:

* Removed the `update_totals` function from `donation.js` and migrated its functionality to the server-side `compute_total_and_validate` method for better data integrity and maintainability. [[1]](diffhunk://#diff-56e17e48a0c1ff35834d3eeb4a3101c5aaa57eec6dfb916145ee51f31b7d58a7L35) [[2]](diffhunk://#diff-56e17e48a0c1ff35834d3eeb4a3101c5aaa57eec6dfb916145ee51f31b7d58a7L44-L63)