### PR TITLE
fix(non_profit): update Donation paid status when Payment Entry is submitted or cancelled

### DIFF
--- a/non_profit/hooks.py
+++ b/non_profit/hooks.py
@@ -110,13 +110,12 @@ override_doctype_class = {
 # ---------------
 # Hook on document methods and events
 
-# doc_events = {
-# 	"*": {
-# 		"on_update": "method",
-# 		"on_cancel": "method",
-# 		"on_trash": "method"
-#	}
-# }
+doc_events = {
+	"Payment Entry": {
+		"on_submit": "non_profit.non_profit.doctype.donation.donation.update_donation_payment_status",
+		"on_cancel": "non_profit.non_profit.doctype.donation.donation.update_donation_payment_status",
+	}
+}
 
 # Scheduled Tasks
 # ---------------

--- a/non_profit/non_profit/doctype/donation/donation.py
+++ b/non_profit/non_profit/doctype/donation/donation.py
@@ -32,13 +32,13 @@ class Donation(Document):
 		non_profit_settings = frappe.get_doc(
 			"Non Profit Settings",
 			"Non Profit Settings",
-		) 
-		
+		)
+
 		enable_payment_table = non_profit_settings.get("enable_payment_table_on_donation", 0)
 		total_amount_paid = calculate_donation_paid_amount(self)
 
 		frappe.db.set_value("Donation", self.name, "total_amount_paid", total_amount_paid)
-		
+
 		if enable_payment_table == 1:
 			donation_payments = self.get("donation_payments") or []
 
@@ -311,3 +311,9 @@ def calculate_donation_paid_amount(doc):
 			total_paid += flt(ref.allocated_amount)
 
 	return total_paid
+
+def update_donation_payment_status(payment_entry, method):
+	for ref in payment_entry.references:
+		if ref.reference_doctype == "Donation" and ref.reference_name:
+			donation = frappe.get_doc("Donation", ref.reference_name)
+			donation.compute_total_and_validate()


### PR DESCRIPTION
Previously, Donations only updated their `paid` status during validation or explicit events (e.g., Razorpay webhook).  
When a Payment Entry was created against a Donation, the Donation did not automatically recalculate its payment status.

This commit hooks into Payment Entry `on_submit` and `on_cancel` events to:
- Find linked Donations from `Payment Entry Reference` table.
- Call `compute_total_and_validate()` to update `total_amount_paid` and `paid` flags.

Ensures Donations always reflect the correct paid status after any payment activity.
