### PR TITLE
revert: reverted to updating linked donations on payment entry submit/cancel

### DIFF
--- a/non_profit/hooks.py
+++ b/non_profit/hooks.py
@@ -110,12 +110,8 @@ override_doctype_class = {
 # ---------------
 # Hook on document methods and events
 
-doc_events = {
-	"Payment Entry": {
-		"on_submit": "non_profit.non_profit.doctype.donation.donation.update_donation_payment_status",
-		"on_cancel": "non_profit.non_profit.doctype.donation.donation.update_donation_payment_status",
-	}
-}
+# doc_events = {
+# }
 
 # Scheduled Tasks
 # ---------------

--- a/non_profit/non_profit/custom_doctype/payment_entry.py
+++ b/non_profit/non_profit/custom_doctype/payment_entry.py
@@ -15,6 +15,22 @@ from erpnext.setup.utils import get_exchange_rate
 
 
 class NonProfitPaymentEntry(PaymentEntry):
+	def on_submit(self):
+		self.update_linked_donations()
+
+	def on_cancel(self):
+		self.update_linked_donations()
+
+	def update_linked_donations(self):
+		donations = {
+			ref.reference_name
+			for ref in self.references
+			if ref.reference_doctype == "Donation"
+		}
+		for donation in donations:
+			doc = frappe.get_doc("Donation", donation)
+			doc.compute_total_and_validate()
+
 	def validate_reference_documents(self):
 		valid_reference_doctypes = self.get_valid_reference_doctypes()
 

--- a/non_profit/non_profit/doctype/donation/donation.py
+++ b/non_profit/non_profit/doctype/donation/donation.py
@@ -311,9 +311,3 @@ def calculate_donation_paid_amount(doc):
 			total_paid += flt(ref.allocated_amount)
 
 	return total_paid
-
-def update_donation_payment_status(payment_entry, method):
-	for ref in payment_entry.references:
-		if ref.reference_doctype == "Donation" and ref.reference_name:
-			donation = frappe.get_doc("Donation", ref.reference_name)
-			donation.compute_total_and_validate()


### PR DESCRIPTION
### Overview
This commit restores the behavior in the **Payment Entry** doctype to update linked **Donation** records whenever a Payment Entry is **submitted** or **cancelled** in the overridden Payment Entry class, removing the added hooks.py doc events

### Changes
- Added back the `on_submit` and `on_cancel` hooks to trigger `update_linked_donations()`.
- `update_linked_donations()`:
  - Finds all linked **Donation** documents in `self.references`.
  - Calls `compute_total_and_validate()` on each linked Donation to ensure totals are recalculated and validated.

### Why This Matters
- Ensures that donations linked to Payment Entries always reflect accurate totals after payment status changes.
- Maintains data consistency between Payment Entries and Donation records.