### PR TITLE
fix(payment_entry): ensure gl entries post correctly when submitting/cancelling Payment Entry

### DIFF
--- a/non_profit/non_profit/custom_doctype/payment_entry.py
+++ b/non_profit/non_profit/custom_doctype/payment_entry.py
@@ -16,9 +16,11 @@ from erpnext.setup.utils import get_exchange_rate
 
 class NonProfitPaymentEntry(PaymentEntry):
 	def on_submit(self):
+		super().on_submit()
 		self.update_linked_donations()
 
 	def on_cancel(self):
+		super().on_cancel()
 		self.update_linked_donations()
 
 	def update_linked_donations(self):


### PR DESCRIPTION
## Summary
This PR fixes an issue where **GL entries were not being posted** when a `Payment Entry` was submitted or canceled in the custom `NonProfitPaymentEntry` class.

### Root Cause
The overridden `on_submit` and `on_cancel` methods did not call their parent implementations, which meant the standard ERPNext ledger posting logic was skipped.

### Solution
- Added `super().on_submit()` and `super().on_cancel()` calls.
- This ensures that the default posting and reversal of GL entries is executed before updating linked Donations.

---

## Before

<img width="1323" height="724" alt="image" src="https://github.com/user-attachments/assets/80189c5b-c9b6-4ba1-bf55-dbf0505b52e8" />

---

## After

<img width="1323" height="724" alt="image" src="https://github.com/user-attachments/assets/4556e588-c649-4312-88ef-1faf4b7ce80b" />

---
