### PR TITLE
feat(volunteer): add Volunteer Status doctype and default statuses

### DIFF
--- a/non_profit/fixtures/volunteer_status.json
+++ b/non_profit/fixtures/volunteer_status.json
@@ -1,0 +1,20 @@
+[
+ {
+  "docstatus": 0,
+  "doctype": "Volunteer Status",
+  "modified": "2025-08-22 10:32:20.163262",
+  "name": "Available"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Volunteer Status",
+  "modified": "2025-08-22 10:32:36.349885",
+  "name": "Unavailable"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Volunteer Status",
+  "modified": "2025-08-22 10:32:46.084005",
+  "name": "Engaged"
+ }
+]

--- a/non_profit/hooks.py
+++ b/non_profit/hooks.py
@@ -216,5 +216,8 @@ fixtures = [
             ["dt", "=", "Member"],
             ["fieldname", "in", ["custom_company", "custom_branch"]],
         ],
+    },
+    {
+        "doctype": "Volunteer Status"
     }
 ]

--- a/non_profit/non_profit/doctype/volunteer/volunteer.json
+++ b/non_profit/non_profit/doctype/volunteer/volunteer.json
@@ -13,6 +13,7 @@
   "branch",
   "column_break_5",
   "volunteer_type",
+  "status",
   "email",
   "image",
   "volunteer_availability_and_skills_details",
@@ -147,11 +148,17 @@
    "in_standard_filter": 1,
    "label": "Branch",
    "options": "Branch"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Link",
+   "label": "Status",
+   "options": "Volunteer Status"
   }
  ],
  "image_field": "image",
  "links": [],
- "modified": "2024-12-16 11:08:54.407089",
+ "modified": "2025-08-22 10:31:42.116097",
  "modified_by": "Administrator",
  "module": "Non Profit",
  "name": "Volunteer",
@@ -173,6 +180,7 @@
  ],
  "quick_entry": 1,
  "restrict_to_domain": "Non Profit",
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/non_profit/non_profit/doctype/volunteer_status/test_volunteer_status.py
+++ b/non_profit/non_profit/doctype/volunteer_status/test_volunteer_status.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestVolunteerStatus(FrappeTestCase):
+	pass

--- a/non_profit/non_profit/doctype/volunteer_status/volunteer_status.js
+++ b/non_profit/non_profit/doctype/volunteer_status/volunteer_status.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Volunteer Status", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/non_profit/non_profit/doctype/volunteer_status/volunteer_status.json
+++ b/non_profit/non_profit/doctype/volunteer_status/volunteer_status.json
@@ -1,0 +1,44 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "prompt",
+ "creation": "2025-08-22 10:31:10.629838",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_sy8y"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_sy8y",
+   "fieldtype": "Section Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-08-22 10:31:20.485189",
+ "modified_by": "Administrator",
+ "module": "Non Profit",
+ "name": "Volunteer Status",
+ "naming_rule": "Set by user",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/non_profit/non_profit/doctype/volunteer_status/volunteer_status.py
+++ b/non_profit/non_profit/doctype/volunteer_status/volunteer_status.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class VolunteerStatus(Document):
+	pass


### PR DESCRIPTION
This pull request introduces a new `Volunteer Status` DocType to the non-profit module and integrates volunteer status tracking throughout the volunteer management workflow. The changes include the creation of the DocType, its fixtures, backend and frontend files, and updates to the `Volunteer` DocType to link volunteers to their status.

**Volunteer Status DocType Implementation:**

* Added new DocType: `Volunteer Status` with backend model (`volunteer_status.py`), frontend script stub (`volunteer_status.js`), and permissions, supporting status management for volunteers. [[1]](diffhunk://#diff-d2a35024c541d5ec03f94de91c83762e5893e7d134172e2e8cd2d5846e091732R1-R44) [[2]](diffhunk://#diff-a658ad7740fe2a29e4f57c709154063ca05e58db173bdb27bc41c6e58355ed4cR1-R9) [[3]](diffhunk://#diff-7f97dff4454032b85959359899bf7c500ee85dc67824128ede0fef94639aefe8R1-R8)
* Added test file for the new DocType: `test_volunteer_status.py` for future unit tests.
* Created fixtures for initial statuses (`Available`, `Unavailable`, `Engaged`) in `volunteer_status.json`.

**Integration with Volunteer Management:**

* Updated `Volunteer` DocType to add a `status` field (linked to `Volunteer Status`) and included it in the field order, filters, and metadata. [[1]](diffhunk://#diff-e1cdc574b7e366d35ff3e7c5b9809fd9de9f5e0204a57a63570869bb58d465b4R16) [[2]](diffhunk://#diff-e1cdc574b7e366d35ff3e7c5b9809fd9de9f5e0204a57a63570869bb58d465b4R151-R161) [[3]](diffhunk://#diff-e1cdc574b7e366d35ff3e7c5b9809fd9de9f5e0204a57a63570869bb58d465b4R183)
* Registered `Volunteer Status` in the hooks for fixture loading.