### PR TITLE
feat(deployment): add status field to Volunteer Deployment Assignee doctype

### DIFF
--- a/non_profit/non_profit/doctype/volunteer_deployment_assignee/volunteer_deployment_assignee.json
+++ b/non_profit/non_profit/doctype/volunteer_deployment_assignee/volunteer_deployment_assignee.json
@@ -6,7 +6,8 @@
  "engine": "InnoDB",
  "field_order": [
   "volunteer",
-  "column_break_qbmp"
+  "column_break_qbmp",
+  "status"
  ],
  "fields": [
   {
@@ -20,13 +21,19 @@
    "label": "Volunteer",
    "options": "Volunteer",
    "reqd": 1
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Pending\nAccepted\nRejected"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-22 09:02:52.217028",
+ "modified": "2025-08-22 10:46:04.657005",
  "modified_by": "Administrator",
  "module": "Non Profit",
  "name": "Volunteer Deployment Assignee",

--- a/non_profit/non_profit/doctype/volunteer_deployment_assignee/volunteer_deployment_assignee.json
+++ b/non_profit/non_profit/doctype/volunteer_deployment_assignee/volunteer_deployment_assignee.json
@@ -26,7 +26,8 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "Pending\nAccepted\nRejected"
+   "options": "Pending\nAccepted\nRejected",
+   "default": "Pending"
   }
  ],
  "grid_page_length": 50,


### PR DESCRIPTION
This pull request adds a new `status` field to the `Volunteer Deployment Assignee` doctype, allowing each volunteer assignment to be tracked as Pending, Accepted, or Rejected.

Field additions and configuration:

* Added a new `status` field of type `Select` with options "Pending", "Accepted", and "Rejected" to the `volunteer_deployment_assignee.json` file.
* Updated the `field_order` array to include the new `status` field after `column_break_qbmp`.