### PR TITLE
feat(members): allow creating members from volunteers and vice versa

### DIFF
--- a/non_profit/fixtures/property_setter.json
+++ b/non_profit/fixtures/property_setter.json
@@ -1,0 +1,34 @@
+[
+ {
+  "default_value": null,
+  "doc_type": "Employee",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "gender",
+  "is_system_generated": 0,
+  "modified": "2025-08-29 13:21:19.336637",
+  "module": "Non Profit",
+  "name": "Employee-gender-reqd",
+  "property": "reqd",
+  "property_type": null,
+  "row_name": "",
+  "value": "0"
+ },
+ {
+  "default_value": null,
+  "doc_type": "Employee",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "date_of_birth",
+  "is_system_generated": 0,
+  "modified": "2025-08-29 13:21:04.140606",
+  "module": "Non Profit",
+  "name": "Employee-date_of_birth-reqd",
+  "property": "reqd",
+  "property_type": null,
+  "row_name": "",
+  "value": "0"
+ }
+]

--- a/non_profit/hooks.py
+++ b/non_profit/hooks.py
@@ -40,6 +40,7 @@ doctype_js = {
     "Job Opening": "non_profit/overrides/client/job_opening.js",
     "Employee Onboarding": "non_profit/overrides/client/employee_onboarding.js",
     "Membership": "non_profit/overrides/client/membership.js",
+    "Employee": "non_profit/overrides/client/employee.js"
 }
 
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
@@ -221,7 +222,6 @@ website_route_rules = [
     {"from_route": "/vmms-portal/<path:app_path>", "to_route": "vmms-portal"},
 ]
 
-
 fixtures = [
     {
         "doctype": "Calendar View",
@@ -252,6 +252,12 @@ fixtures = [
         "doctype": "Designation",
         "filters": [
             ["name", "=", "Volunteer"],
+        ],
+    },
+    {
+        "doctype": "Property Setter",
+        "filters": [
+            ["module", "=", "Non Profit"],
         ],
     },
 ]

--- a/non_profit/non_profit/api.py
+++ b/non_profit/non_profit/api.py
@@ -410,3 +410,26 @@ def create_availability_slot(slot_data):
         frappe.log_error(frappe.get_traceback(), "Availability Slot Creation Error")
 
         frappe.throw("Availability Slot Creation Error")
+
+
+@frappe.whitelist()
+def create_volunteer(user_details):
+	volunteer = frappe.new_doc("Employee")
+	volunteer.first_name = user_details.fullname
+	volunteer.full_name = user_details.fullname
+	volunteer.email = user_details.email
+	volunteer.phone = user_details.phone
+	volunteer.is_volunteer = 1
+	volunteer.date_of_joining = frappe.utils.today()
+	volunteer.insert(ignore_permissions=True)
+	return volunteer.name
+
+@frappe.whitelist()
+def create_member(name):
+    volunteer_details = frappe.get_doc("Employee", name)
+    member = frappe.new_doc("Member")
+    member.member_name = volunteer_details.employee_name
+    member.email_id = volunteer_details.personal_email
+    member.volunteer = volunteer_details.name
+    member.insert(ignore_permissions=True)
+    return member.name

--- a/non_profit/non_profit/doctype/member/member.js
+++ b/non_profit/non_profit/doctype/member/member.js
@@ -1,67 +1,92 @@
 // Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Member', {
-	setup: function(frm) {
-		frappe.db.get_single_value('Non Profit Settings', 'enable_razorpay_for_memberships').then(val => {
-			if (val && (frm.doc.subscription_id || frm.doc.customer_id)) {
-				frm.set_df_property('razorpay_details_section', 'hidden', false);
-			}
-		})
-	},
+frappe.ui.form.on("Member", {
+  setup: function (frm) {
+    frappe.db
+      .get_single_value(
+        "Non Profit Settings",
+        "enable_razorpay_for_memberships"
+      )
+      .then((val) => {
+        if (val && (frm.doc.subscription_id || frm.doc.customer_id)) {
+          frm.set_df_property("razorpay_details_section", "hidden", false);
+        }
+      });
+  },
 
-	refresh: function(frm) {
+  refresh: function (frm) {
+    frappe.dynamic_link = {
+      doc: frm.doc,
+      fieldname: "name",
+      doctype: "Member",
+    };
 
-		frappe.dynamic_link = {doc: frm.doc, fieldname: 'name', doctype: 'Member'};
+    frm.toggle_display(["address_html", "contact_html"], !frm.doc.__islocal);
 
-		frm.toggle_display(['address_html','contact_html'], !frm.doc.__islocal);
+    if (!frm.doc.__islocal) {
+      frappe.contacts.render_address_and_contact(frm);
 
-		if(!frm.doc.__islocal) {
-			frappe.contacts.render_address_and_contact(frm);
+      // custom buttons
+      frm.add_custom_button(__("Accounting Ledger"), function () {
+        if (frm.doc.customer) {
+          frappe.set_route("query-report", "General Ledger", {
+            party_type: "Customer",
+            party: frm.doc.customer,
+          });
+        } else {
+          frappe.set_route("query-report", "General Ledger", {
+            party_type: "Member",
+            party: frm.doc.name,
+          });
+        }
+      });
 
-			// custom buttons
-			frm.add_custom_button(__('Accounting Ledger'), function() {
-				if (frm.doc.customer) {
-					frappe.set_route('query-report', 'General Ledger', {party_type: 'Customer', party: frm.doc.customer});
-				} else {
-					frappe.set_route('query-report', 'General Ledger', {party_type: 'Member', party: frm.doc.name});
-				}
-			});
+      frm.add_custom_button(__("Accounts Receivable"), function () {
+        frappe.set_route("query-report", "Accounts Receivable", {
+          customer: frm.doc.customer,
+        });
+      });
 
-			frm.add_custom_button(__('Accounts Receivable'), function() {
-				frappe.set_route('query-report', 'Accounts Receivable', {customer: frm.doc.customer});
-			});
+      if (!frm.doc.customer) {
+        frm.add_custom_button(__("Create Customer"), () => {
+          frm.call("make_customer_and_link").then(() => {
+            frm.reload_doc();
+          });
+        });
+      }
 
-			if (!frm.doc.customer) {
-				frm.add_custom_button(__('Create Customer'), () => {
-					frm.call('make_customer_and_link').then(() => {
-						frm.reload_doc();
-					});
-				});
-			}
+      if (!frm.doc.volunteer) {
+        frm.add_custom_button(__("Create Volunteer"), () => {
+          frm.call("make_volunteer_and_link").then(() => {
+            frm.reload_doc();
+          });
+        });
+      }
 
-			// indicator
-			erpnext.utils.set_party_dashboard_indicators(frm);
+      // indicator
+      erpnext.utils.set_party_dashboard_indicators(frm);
+    } else {
+      frappe.contacts.clear_address_and_contact(frm);
+    }
 
-		} else {
-			frappe.contacts.clear_address_and_contact(frm);
-		}
-
-		frappe.call({
-			method:"frappe.client.get_value",
-			args:{
-				'doctype':"Membership",
-				'filters':{'member': frm.doc.name},
-				'fieldname':[
-					'to_date'
-				]
-			},
-			callback: function (data) {
-				if(data.message) {
-					frappe.model.set_value(frm.doctype,frm.docname,
-						"membership_expiry_date", data.message.to_date);
-				}
-			}
-		});
-	}
+    frappe.call({
+      method: "frappe.client.get_value",
+      args: {
+        doctype: "Membership",
+        filters: { member: frm.doc.name },
+        fieldname: ["to_date"],
+      },
+      callback: function (data) {
+        if (data.message) {
+          frappe.model.set_value(
+            frm.doctype,
+            frm.docname,
+            "membership_expiry_date",
+            data.message.to_date
+          );
+        }
+      },
+    });
+  },
 });

--- a/non_profit/non_profit/doctype/member/member.json
+++ b/non_profit/non_profit/doctype/member/member.json
@@ -19,6 +19,8 @@
   "customer_name",
   "supplier_section",
   "supplier",
+  "section_break_dblh",
+  "volunteer",
   "address_contacts",
   "address_html",
   "column_break_9",
@@ -60,8 +62,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Membership Type",
-   "options": "Membership Type",
-   "reqd": 1
+   "options": "Membership Type"
   },
   {
    "fieldname": "image",
@@ -166,14 +167,27 @@
    "fieldtype": "Select",
    "label": "Subscription Status",
    "options": "\nActive\nHalted"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_dblh",
+   "fieldtype": "Section Break",
+   "label": "Volunteer"
+  },
+  {
+   "fieldname": "volunteer",
+   "fieldtype": "Link",
+   "label": "Volunteer",
+   "options": "Employee"
   }
  ],
  "image_field": "image",
  "links": [],
- "modified": "2021-07-11 14:27:26.368039",
+ "modified": "2025-08-29 13:32:59.040381",
  "modified_by": "Administrator",
  "module": "Non Profit",
  "name": "Member",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -203,8 +217,10 @@
  ],
  "quick_entry": 1,
  "restrict_to_domain": "Non Profit",
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "member_name",
  "track_changes": 1
 }

--- a/non_profit/non_profit/doctype/member/member.py
+++ b/non_profit/non_profit/doctype/member/member.py
@@ -11,6 +11,7 @@ from frappe.utils import cint, get_link_to_form
 from payments.utils import get_payment_gateway_controller
 
 from non_profit.non_profit.doctype.membership_type.membership_type import get_membership_type
+from non_profit.non_profit.api import create_volunteer
 
 
 class Member(Document):
@@ -70,6 +71,20 @@ class Member(Document):
 		self.save()
 		frappe.msgprint(_("Customer {0} has been created succesfully.").format(self.customer))
 
+	@frappe.whitelist()
+	def make_volunteer_and_link(self):
+		if self.volunteer:
+			frappe.msgprint(_("A volunteer is already linked to this Member"))
+
+		volunteer =  create_volunteer(frappe._dict({
+			'fullname': self.member_name,
+			'email': self.email_id,
+			'phone': None
+		}))
+
+		self.volunteer = volunteer
+		self.save()
+		frappe.msgprint(_("Volunteer {0} has been created succesfully.").format(self.volunteer))
 
 def get_or_create_member(user_details):
 	member_list = frappe.get_all("Member", filters={'email': user_details.email, 'membership_type': user_details.plan_id})

--- a/non_profit/non_profit/overrides/client/employee.js
+++ b/non_profit/non_profit/overrides/client/employee.js
@@ -1,0 +1,43 @@
+// Copyright (c) 2025, Frappe and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Employee", {
+  refresh(frm) {
+    frm.set_query("branch", function (doc) {
+      if (!doc.company) {
+        return {
+          filters: {
+            name: ["in", []],
+          },
+        };
+      }
+
+      return {
+        filters: {
+          company: doc.company,
+        },
+      };
+    });
+
+    frappe.db
+      .get_value("Member", { email_id: frm.doc.personal_email }, "name")
+      .then((r) => {
+        if (!(r && r.message && r.message.name)) {
+          frm.add_custom_button(__("Create Member"), () => {
+            frm
+              .call({
+                method: "non_profit.non_profit.api.create_member",
+                args: { name: frm.doc.name },
+              })
+              .then(() => {
+                frappe.show_alert({
+                  message: __("Member created successfully"),
+                  indicator: "green",
+                });
+                frm.reload_doc();
+              });
+          });
+        }
+      });
+  },
+});


### PR DESCRIPTION
This pull request introduces enhancements to the volunteer and member management features in the Non Profit module, focusing on tighter integration between `Member` and `Employee` records, new automation for creating linked records, and updates to the UI and data model. The changes streamline workflows for associating volunteers with members and vice versa, and improve customization and fixture management.

**Member and Volunteer Integration:**

* Added a new `volunteer` field (linked to `Employee`) and a dedicated "Volunteer" section to the `Member` doctype, allowing members to be explicitly associated with volunteers. (`non_profit/non_profit/doctype/member/member.json`) [[1]](diffhunk://#diff-4afd27ab71ab6762d1c7769e1a486750d1c57df7f60239428e67e337e96c85acR22-R23) [[2]](diffhunk://#diff-4afd27ab71ab6762d1c7769e1a486750d1c57df7f60239428e67e337e96c85acR170-R190)
* Implemented the `make_volunteer_and_link` method on the `Member` doctype, enabling users to create a linked `Employee` (volunteer) directly from a member record. (`non_profit/non_profit/doctype/member/member.py`, `non_profit/non_profit/api.py`) [[1]](diffhunk://#diff-adc95b9dac2fae0c885e6a5f2e45b0996fa2520a1d348731e6b3971c87e5c610R74-R87) [[2]](diffhunk://#diff-8d66a426671eab773446aec8f793d51b7dcb90b7b2135cad15c6fa0a8aba605bR413-R435)
* Updated the member form UI to show a "Create Volunteer" button when no volunteer is linked, improving usability. (`non_profit/non_profit/doctype/member/member.js`)

**Employee and Member Cross-Linking:**

* Added a client-side override for the `Employee` doctype that provides a "Create Member" button if no member is linked by email, automating member creation from an employee record. (`non_profit/non_profit/overrides/client/employee.js`)
* Registered the new employee client override in the hooks configuration for automatic inclusion. (`non_profit/hooks.py`)

**Fixtures and Data Model Updates:**

* Added a fixture for the `Property Setter` doctype to ensure custom field requirements are included for deployment, and provided sample property setter data for `Employee` fields. (`non_profit/hooks.py`, `non_profit/fixtures/property_setter.json`) [[1]](diffhunk://#diff-2b9d8c940a4521498aefa03b308211d92c4edbd40db7a133a3a3f58d93bdd43eR257-R262) [[2]](diffhunk://#diff-336b2a7209713e41236624e83315ecf0fcb9ee6411d6a26a271a359f65125c2bR1-R34)
* Minor adjustments to the `Member` doctype, such as removing the required flag from `membership_type`, updating metadata, and setting row format to "Dynamic". (`non_profit/non_profit/doctype/member/member.json`) [[1]](diffhunk://#diff-4afd27ab71ab6762d1c7769e1a486750d1c57df7f60239428e67e337e96c85acL63-R65) [[2]](diffhunk://#diff-4afd27ab71ab6762d1c7769e1a486750d1c57df7f60239428e67e337e96c85acR220-R223)