### PR TITLE
refactor: improve job application filtering and employee field mapping

### DIFF
--- a/non_profit/non_profit/api.py
+++ b/non_profit/non_profit/api.py
@@ -1157,7 +1157,7 @@ def fetch_applications(email: str):
 
     applicants = frappe.get_all(
         "Job Applicant",
-        filters={"email_id": email},
+        filters={"email_id": email, "job_title": ("!=", None)},
         fields=[
             "name",
             "applicant_name",
@@ -1177,7 +1177,7 @@ def fetch_applications(email: str):
         return []
 
     for app in applicants:
-        job_opening = frappe.get_doc("Job Opening", app.get("job_title")).as_dict()
+        job_opening = frappe.get_doc("Job Opening", app.get("job_title")).as_dict() if app.get("job_title") else {}
         app["job_opening_details"] = job_opening
 
     return applicants

--- a/non_profit/non_profit/overrides/client/employee.js
+++ b/non_profit/non_profit/overrides/client/employee.js
@@ -105,7 +105,7 @@ function fetchJobApplicantDetails(frm) {
       phone_number: "cell_number",
       idpassport_number: "id_passport_number",
       cover_letter: "bio",
-      profile_photo: "image",
+      // profile_photo: "image",
     };
 
     const table_fields = [

--- a/non_profit/non_profit/overrides/server/employee.py
+++ b/non_profit/non_profit/overrides/server/employee.py
@@ -186,7 +186,7 @@ def update_fields_from_applicant(doc: Document) -> bool:
             "phone_number": "cell_number",
             "idpassport_number": "id_passport_number",
             "cover_letter": "bio",
-            "profile_photo": "image"
+            # "profile_photo": "image"
         }
         
         for applicant_field, employee_field in field_mapping.items():


### PR DESCRIPTION
This pull request introduces improvements to how job applicant data is fetched and mapped, specifically focusing on filtering out incomplete applications and adjusting field mappings related to profile photos.

**Data fetching improvements:**

* Updated the filter in `fetch_applications` (in `non_profit/non_profit/api.py`) to exclude job applicants where `job_title` is `None`, ensuring only complete applications are returned.
* Modified the retrieval of job opening details in `fetch_applications` to safely handle cases where `job_title` might be missing, preventing errors and returning an empty dictionary when necessary.

**Field mapping adjustments:**

* Commented out the mapping for `profile_photo` in both the client-side `fetchJobApplicantDetails` function (`non_profit/non_profit/overrides/client/employee.js`) and the server-side `update_fields_from_applicant` function (`non_profit/non_profit/overrides/server/employee.py`), indicating that profile photo data is no longer transferred between applicant and employee records. [[1]](diffhunk://#diff-4b338332659d922bacecb7138685cc5ddc8b450a47c7b0f86a9602c4dfaa177aL108-R108) [[2]](diffhunk://#diff-ca446ef4d1b66051f79c0d76733eacdf4805d1957596f9072da51363d4a39a38L189-R189)