### PR TITLE
fix(user): add module and role profile for new users in create_user function

### DIFF
--- a/non_profit/non_profit/user.py
+++ b/non_profit/non_profit/user.py
@@ -52,6 +52,8 @@ def create_user(**kwargs):
                 "gender": kwargs.get("gender"),
                 "enabled": 1,
                 "default_app": "non_profit",
+                "module_profile": "Member",
+                "role_profile_name": "Member",
             }
         )
 


### PR DESCRIPTION
This pull request makes a minor update to the user creation logic in `non_profit/non_profit/user.py`. The change ensures that new users are assigned the correct module and role profile information.

* Added `module_profile` and `role_profile_name` fields with the value "Member" to the user creation dictionary in `create_user`.