### PR TITLE
refactor: remove branch references from job-related components and update related logic

### DIFF
--- a/frontend/src/components/JobCard.vue
+++ b/frontend/src/components/JobCard.vue
@@ -8,13 +8,6 @@
         {{ job.job_title }}
       </h2>
       <div class="mt-2 flex flex-col gap-1">
-        <div v-if="job.branch" class="flex items-center gap-1 mb-2">
-          <span
-            class="text-sm font-semibold bg-red-100 text-red-800 px-3 py-1 rounded-full border border-red-200 shadow-sm"
-          >
-            {{ job.branch }}
-          </span>
-        </div>
         <div v-if="job.department" class="flex items-center gap-1">
           <span
             class="text-sm text-gray-700 bg-gray-100 px-3 py-1 rounded-full border border-gray-200"

--- a/frontend/src/components/Modals/JobApplicationModal.vue
+++ b/frontend/src/components/Modals/JobApplicationModal.vue
@@ -15,16 +15,8 @@
               <Link
                 v-model="form.branch"
                 :label="__('Branch')"
-                doctype="Branch"
+                doctype="Company"
                 :required="true"
-                @update:modelValue="onBranchSelect"
-              />
-              <FormControl
-                v-model="form.company"
-                :label="__('Region')"
-                type="text"
-                :disabled="true"
-                placeholder="Auto-filled from branch"
               />
             </div>
           </section>
@@ -304,7 +296,6 @@ const applicationId = ref(null);
 
 const form = ref({
   company: "",
-  branch: "",
   surname: "",
   other_names: "",
   email_id: "",
@@ -408,7 +399,6 @@ function submitResume() {
     {},
     {
       validate() {
-        if (!form.value.branch) return "Branch is required";
         if (!form.value.company) return "Company is required";
         if (!hidePersonalInfo.value) {
           if (!form.value.surname) return "Surname is required";
@@ -449,38 +439,4 @@ watch(
   },
   { immediate: true }
 );
-
-const company = createResource({
-  url: "non_profit.non_profit.api.search_doctype",
-  method: "POST",
-  auto: false,
-  makeParams() {
-    return {
-      doctype: "Branch",
-      name: form.value.branch,
-    };
-  },
-  transform: (data) => {
-    if (data && data.length > 0) {
-      form.value.company = data[0].description || "";
-      return data[0];
-    }
-    return null;
-  },
-});
-
-async function onBranchSelect(branchName) {
-  if (!branchName) {
-    form.value.company = "";
-    return;
-  }
-
-  form.value.branch = branchName;
-
-  await company.submit();
-
-  if (company.data?.company) {
-    form.value.company = company.data.company;
-  }
-}
 </script>

--- a/frontend/src/components/Volunteer.vue
+++ b/frontend/src/components/Volunteer.vue
@@ -352,7 +352,6 @@ const assignedProjects = ref<Project[]>([]);
 const availabilityslot = reactive({
   employee: roleResource.data.employee,
   company: roleResource.data.company,
-  branch: roleResource.data.branch,
   user: roleResource.data.name,
   starts_on: "",
   ends_on: "",
@@ -361,7 +360,7 @@ const availabilityslot = reactive({
 const assignmentDecision = createResource({
   url: "non_profit.non_profit.api.accept_assignment",
   makeParams(values) {
-    return values; 
+    return values;
   },
 });
 

--- a/frontend/src/pages/JobApplication.vue
+++ b/frontend/src/pages/JobApplication.vue
@@ -63,9 +63,7 @@
                 </span>
               </div>
               <p class="text-red-700 font-medium">{{ app.company }}</p>
-              <p v-if="app.branch" class="text-gray-500 text-sm">
-                {{ app.branch }}
-              </p>
+
               <p v-if="app.designation" class="text-gray-500 text-sm">
                 <strong>Designation:</strong> {{ app.designation }}
               </p>

--- a/frontend/src/pages/JobApplicationDetail.vue
+++ b/frontend/src/pages/JobApplicationDetail.vue
@@ -51,9 +51,6 @@
             </router-link>
             <div class="text-lg font-medium text-red-600">
               {{ job.data.company }}
-              <span v-if="job.data.branch" class="text-gray-500 ml-2 text-base">
-                • {{ job.data.branch }}
-              </span>
             </div>
             <div
               v-if="job.data.location || job.data.country"

--- a/frontend/src/pages/JobDetail.vue
+++ b/frontend/src/pages/JobDetail.vue
@@ -81,12 +81,6 @@
               </h1>
               <div class="text-lg font-medium text-red-600">
                 {{ job.data.company }}
-                <span
-                  v-if="job.data.branch"
-                  class="text-gray-500 ml-2 text-base"
-                >
-                  • {{ job.data.branch }}
-                </span>
               </div>
               <div
                 v-if="job.data.location || job.data.country"

--- a/frontend/src/pages/Jobs.vue
+++ b/frontend/src/pages/Jobs.vue
@@ -99,19 +99,10 @@
             <MultiSelectList
               doctype="Company"
               v-model="companies"
-              :label="__('Region')"
+              :label="__('Branch / Region')"
               class="w-full"
               @change="updateJobs"
               :cols="2"
-            />
-            <MultiSelectList
-              doctype="Branch"
-              v-model="branches"
-              :label="__('Branch')"
-              :filters="branchFilters"
-              class="w-full"
-              @change="updateJobs"
-              :cols="3"
             />
           </div>
         </div>
@@ -171,7 +162,6 @@ const designation = ref(null);
 const department = ref(null);
 const searchQuery = ref("");
 const companies = ref([]);
-const branches = ref([]);
 const showFilters = ref(false);
 const filters = ref({});
 const orFilters = ref({});
@@ -216,8 +206,6 @@ const updateFilters = () => {
   else delete filters.value.department;
   if (companies.value?.length) filters.value.company = ["in", companies.value];
   else delete filters.value.company;
-  if (branches.value?.length) filters.value.branch = ["in", branches.value];
-  else delete filters.value.branch;
   if (searchQuery.value) {
     orFilters.value = {
       job_title: ["like", `%${searchQuery.value}%`],
@@ -227,13 +215,8 @@ const updateFilters = () => {
   } else orFilters.value = {};
 };
 
-const branchFilters = computed(() =>
-  companies.value?.length ? { company: ["in", companies.value] } : {}
-);
-
 const clearFilters = () => {
   companies.value = [];
-  branches.value = [];
   jobType.value = null;
   designation.value = null;
   department.value = null;
@@ -243,10 +226,8 @@ const clearFilters = () => {
 
 watch([jobType, designation, department, currentTab], updateJobs);
 watch(companies, () => {
-  branches.value = [];
   updateJobs();
 });
-watch(branches, updateJobs);
 watch(jobs, () => (jobCount.value = jobs.data?.length || 0));
 
 usePageMeta(() => ({ title: __("Jobs"), icon: brand.favicon }));

--- a/frontend/src/pages/NewJobApplication.vue
+++ b/frontend/src/pages/NewJobApplication.vue
@@ -27,9 +27,6 @@
           </h1>
           <div class="text-lg font-medium text-red-600">
             {{ job.data.company }}
-            <span v-if="job.data.branch" class="text-gray-500 ml-2 text-base">
-              • {{ job.data.branch }}
-            </span>
           </div>
           <div
             v-if="job.data.location || job.data.country"

--- a/non_profit/non_profit/api.py
+++ b/non_profit/non_profit/api.py
@@ -439,7 +439,7 @@ def submit_job_application(job_opening: str = None, id: str = None, **kwargs) ->
                 "Job Opening", job_opening, ["company"]
             )
             if job_opening_data:
-                company = job_opening_data[0] or company
+                company = job_opening_data or company
 
         if not company:
             frappe.throw("Company is required")

--- a/non_profit/non_profit/overrides/server/employee.py
+++ b/non_profit/non_profit/overrides/server/employee.py
@@ -128,10 +128,10 @@ def create_user_for_employee(doc: Document) -> str:
     """
     existing_user = frappe.db.get_value("User", {"email": doc.personal_email}, "name")
     
+    user = None    
     if existing_user:
-        return existing_user
-    
-    try:
+        user = frappe.get_doc("User", existing_user)
+    else:            
         user = frappe.get_doc({
             "doctype": "User",
             "email": doc.personal_email,
@@ -142,9 +142,8 @@ def create_user_for_employee(doc: Document) -> str:
             "send_welcome_email": 0,
             "default_app": "non_profit",
         })
-        
         user.insert(ignore_permissions=True)
-        
+    try:
         user.role_profile_name = "Volunteer"
         user.module_profile = "Volunteer"
         user.save(ignore_permissions=True)

--- a/non_profit/non_profit/user.py
+++ b/non_profit/non_profit/user.py
@@ -5,27 +5,6 @@ from frappe.utils.password import update_password
 
 
 @frappe.whitelist(allow_guest=True)
-def sign_up(**kwargs):
-
-    frappe.db.begin()
-
-    try:
-
-        if kwargs.get("category_member"):
-            user = create_user(kwargs)
-
-        if kwargs.get("category_volunteer"):
-            create_volunteer(kwargs)
-
-        frappe.db.commit()
-
-    except Exception as e:
-        frappe.db.rollback()
-        frappe.log_error(frappe.get_traceback(), "Sign Up Error")
-        frappe.throw(str(e))
-
-
-@frappe.whitelist(allow_guest=True)
 def create_user(**kwargs):
 
     try:
@@ -92,8 +71,6 @@ def create_membership(**kwargs):
         member.insert(ignore_permissions=True)
 
         user = frappe.get_doc("User", {"email": member.email_id})
-        user.role_profile_name = "Member"
-        user.module_profile = "Member"
 
         user.save(ignore_permissions=True)
 


### PR DESCRIPTION
This pull request removes the concept of "Branch" from the job application and volunteer flows, consolidating filtering and display logic to use only "Company" (sometimes labeled as "Branch / Region"). The changes simplify both the frontend and backend code, eliminating unnecessary fields and logic related to branches.

**Frontend changes:**

* **Job application and job listing UI:** Removed all references to `branch` from job cards, job application modals, job detail pages, and job filters. Filtering and display now use only `company`, with the label updated to "Branch / Region" where appropriate. (`frontend/src/components/JobCard.vue`, `frontend/src/pages/JobApplication.vue`, `frontend/src/pages/JobApplicationDetail.vue`, `frontend/src/pages/JobDetail.vue`, `frontend/src/pages/Jobs.vue`, `frontend/src/pages/NewJobApplication.vue`) [[1]](diffhunk://#diff-44317ffda7cd568a5c5e31b0175b3a12b0e106061bc77a81b8bc8edb00deeaf9L11-L17) [[2]](diffhunk://#diff-802bbcf2a8b4bf53f4d6804b602eb0f9a07a352d91c136d4bf6ed5fc57e6929eL66-R66) [[3]](diffhunk://#diff-53b805998acb78c81116f0ae9e27c1bdd4783b9eb5f5c161dd7c4521be5e76fbL54-L56) [[4]](diffhunk://#diff-e19aa286c61be71cf4d8b59a6daaa891d2c9e050151dda69c9dc08c3e0412a38L84-L89) [[5]](diffhunk://#diff-949df6362d8e0c34d2977310016d3afc279bbbfb6ee78854d8c3251b0a21b0f9L102-L115) [[6]](diffhunk://#diff-949df6362d8e0c34d2977310016d3afc279bbbfb6ee78854d8c3251b0a21b0f9L174) [[7]](diffhunk://#diff-949df6362d8e0c34d2977310016d3afc279bbbfb6ee78854d8c3251b0a21b0f9L219-L220) [[8]](diffhunk://#diff-949df6362d8e0c34d2977310016d3afc279bbbfb6ee78854d8c3251b0a21b0f9L230-L236) [[9]](diffhunk://#diff-949df6362d8e0c34d2977310016d3afc279bbbfb6ee78854d8c3251b0a21b0f9L246-L249) [[10]](diffhunk://#diff-15707c5a8918149242e0f32565be629f67fb6d7e2a61984015a87dd7bb0f6548L30-L32)
* **Job application modal logic:** Removed the `branch` field and its related autofill logic; the modal now only requires and validates `company`. (`frontend/src/components/Modals/JobApplicationModal.vue`) [[1]](diffhunk://#diff-31513acda562fac5a2c63938cdaa259fc16856df970ba6e63d737084b8f3d3dbL18-L27) [[2]](diffhunk://#diff-31513acda562fac5a2c63938cdaa259fc16856df970ba6e63d737084b8f3d3dbL307) [[3]](diffhunk://#diff-31513acda562fac5a2c63938cdaa259fc16856df970ba6e63d737084b8f3d3dbL411) [[4]](diffhunk://#diff-31513acda562fac5a2c63938cdaa259fc16856df970ba6e63d737084b8f3d3dbL452-L485)
* **Volunteer availability:** Removed the `branch` property from the volunteer availability slot object. (`frontend/src/components/Volunteer.vue`)

**Backend changes:**

* **Job application API:** Adjusted logic to correctly fetch and set the `company` when submitting a job application, removing handling for branches. (`non_profit/non_profit/api.py`)
* **User creation and membership:** Cleaned up user creation logic for volunteers and members, removing redundant role and module profile assignments, and simplifying error handling. (`non_profit/non_profit/overrides/server/employee.py`, `non_profit/non_profit/user.py`) [[1]](diffhunk://#diff-ca446ef4d1b66051f79c0d76733eacdf4805d1957596f9072da51363d4a39a38R131-R134) [[2]](diffhunk://#diff-ca446ef4d1b66051f79c0d76733eacdf4805d1957596f9072da51363d4a39a38L145-R146) [[3]](diffhunk://#diff-1d4ba3b652c8d2b43bad6bcf77e396f57f945934e5b6c682b6ed374ec329048aL7-L27) [[4]](diffhunk://#diff-1d4ba3b652c8d2b43bad6bcf77e396f57f945934e5b6c682b6ed374ec329048aL95-L96)