### PR TITLE
Ft/vmms

### DIFF
--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -138,12 +138,6 @@ const isLogin = ref(false);
 const userEmail = ref("");
 const password = ref("");
 const signInState = ref(false);
-interface RegionOption {
-  label: string;
-  value: string;
-  company: string;
-}
-const branchOptions = ref<RegionOption[]>([]);
 
 const signUpForm = reactive<SignUp>({ ...initialForm });
 
@@ -157,19 +151,6 @@ const genderOptions = [
 const branches = createResource({
   url: "non_profit.non_profit.api.get_branches",
   auto: true,
-  onSuccess(data: any) {
-    branchOptions.value = data.map((branch) => {
-      return {
-        label: branch.name,
-        value: branch.name,
-        company: branch.company,
-      };
-    });
-  },
-});
-
-onMounted(() => {
-  branches.fetch();
 });
 
 const createSignUp = createResource({

--- a/frontend/src/pages/Membership.vue
+++ b/frontend/src/pages/Membership.vue
@@ -47,39 +47,18 @@
         </p>
 
         <div class="bg-white border rounded-lg p-4 shadow-sm">
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div class="flex flex-col">
-              <label
-                for="branch"
-                class="text-sm font-medium text-gray-700 mb-1"
-              >
-                Branch/County
-              </label>
-              <Link
-                required
-                id="branch"
-                doctype="Branch"
-                v-model="membershipForm.branch"
-                placeholder="Select Branch"
-                class="w-full"
-              />
-            </div>
-            <div class="flex flex-col">
-              <label
-                for="region"
-                class="text-sm font-medium text-gray-700 mb-1"
-              >
-                Region
-              </label>
-              <Input
-                id="region"
-                doctype="Company"
-                v-model="membershipForm.region"
-                placeholder="Region"
-                class="w-full"
-                readonly
-              />
-            </div>
+          <div class="flex w-full flex-col">
+            <label for="branch" class="text-sm font-medium text-gray-700 mb-1">
+              Branch/County
+            </label>
+            <Link
+              required
+              id="branch"
+              doctype="Company"
+              v-model="membershipForm.branch"
+              placeholder="Select Branch"
+              class="w-full"
+            />
           </div>
         </div>
 

--- a/frontend/src/pages/Membership.vue
+++ b/frontend/src/pages/Membership.vue
@@ -127,19 +127,7 @@ interface RegionOption {
 }
 const branchOptions = ref<RegionOption[]>([]);
 const user = inject<any>("$user");
-const branches = createResource({
-  url: "non_profit.non_profit.api.get_branches",
-  auto: true,
-  onSuccess(data: any) {
-    branchOptions.value = data.map((branch) => {
-      return {
-        label: branch.name,
-        value: branch.name,
-        company: branch.company,
-      };
-    });
-  },
-});
+
 
 const createMembership = createResource({
   url: "non_profit.non_profit.user.create_membership",
@@ -155,7 +143,6 @@ function cleanUpMembershipForm() {
   registerDialog.value = false;
   membershipForm.membership_type = "";
   membershipForm.amount = 0;
-  membershipForm.region = "";
   membershipForm.branch = "";
   createMembership.error = "";
 }
@@ -164,7 +151,6 @@ const registerDialog = ref(false);
 const membershipForm = reactive({
   membership_type: "",
   amount: 0,
-  region: "",
   branch: "",
   member_name: user.data ? user.data.full_name : "",
   email_id: user.data ? user.data.email : "",
@@ -176,27 +162,8 @@ function selectMembershipType(membershipType: any) {
   registerDialog.value = true;
 }
 
-onMounted(() => {
-  branches.fetch();
-});
-watch(
-  () => membershipForm.branch,
-  (newBranch) => {
-    const selectedBranch = branchOptions.value.find(
-      (b) => b.value === newBranch
-    );
 
-    if (selectedBranch) {
-      membershipForm.region = selectedBranch.company;
-    } else {
-      membershipForm.region = "";
-    }
 
-    if (newBranch) {
-      createMembership.error = "";
-    }
-  }
-);
 
 const submit = () => {
   if (!membershipForm.branch) {

--- a/non_profit/non_profit/api.py
+++ b/non_profit/non_profit/api.py
@@ -684,14 +684,13 @@ def generate_language_code(language_name):
     return base_code + suffix
 
 
-@frappe.whitelist(allow_guest=True)
-def get_regions():
-    return frappe.get_all("Company", filters={"is_group": 0})
+
 
 
 @frappe.whitelist(allow_guest=True)
 def get_branches():
-    return frappe.get_all("Branch", fields=["name", "company"])
+    return frappe.get_all("Company", filters={"is_group": 0})
+
 
 
 @frappe.whitelist(allow_guest=True)

--- a/non_profit/non_profit/doctype/membership/membership.json
+++ b/non_profit/non_profit/doctype/membership/membership.json
@@ -11,6 +11,7 @@
   "membership_type",
   "column_break_3",
   "company",
+  "branch",
   "membership_status",
   "membership_validity_section",
   "from_date",
@@ -137,7 +138,7 @@
   {
    "fieldname": "company",
    "fieldtype": "Link",
-   "label": "Company / Branch",
+   "label": "Company",
    "options": "Company",
    "reqd": 1
   },
@@ -148,6 +149,12 @@
   {
    "fieldname": "column_break_16",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "branch",
+   "fieldtype": "Link",
+   "label": "Branch",
+   "options": "Branch"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -163,7 +170,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2025-09-16 11:51:28.435597",
+ "modified": "2025-09-16 12:57:41.723776",
  "modified_by": "Administrator",
  "module": "Non Profit",
  "name": "Membership",

--- a/non_profit/non_profit/user.py
+++ b/non_profit/non_profit/user.py
@@ -64,7 +64,7 @@ def create_membership(**kwargs):
                 "member_name": kwargs.get("member_name"),
                 "email_id": kwargs.get("email_id"),
                 "membership_type": kwargs.get("membership_type"),
-                "custom_company": kwargs.get("region"),
+                "custom_company": kwargs.get("branch"),
                 "pan_number": kwargs.get("phone_number"),
             }
         )
@@ -84,7 +84,7 @@ def create_membership(**kwargs):
                     "doctype": "Membership",
                     "member": member.name,
                     "membership_type": doc_name,
-                    "company": kwargs.get("region"),
+                    "company": kwargs.get("branch"),
                     "membership_status": "Pending",
                     "from_date": from_date,
                     "to_date": to_date,


### PR DESCRIPTION
This pull request refactors how "Branch" and "Company" information is handled in the membership workflow, both on the frontend and backend. The main change is that "Branch" is now a distinct field, and "Company" is no longer inferred from "Branch" or "Region". The frontend forms and backend APIs have been updated to reflect this separation, simplifying data flow and reducing ambiguity.

**Frontend changes to membership and login forms:**

* Removed the "Region" field and its associated logic from `Membership.vue` and `Login.vue`, including the reactive field, form controls, and watcher that mapped branches to regions. Now, only "Branch" is selected, and "Company" is handled separately. [[1]](diffhunk://#diff-ab0f64eb48db31830aa203bebb51c02f1cdce469e6ab310b005a08c1946c8713L50-L83) [[2]](diffhunk://#diff-ab0f64eb48db31830aa203bebb51c02f1cdce469e6ab310b005a08c1946c8713L179) [[3]](diffhunk://#diff-ab0f64eb48db31830aa203bebb51c02f1cdce469e6ab310b005a08c1946c8713L188) [[4]](diffhunk://#diff-ab0f64eb48db31830aa203bebb51c02f1cdce469e6ab310b005a08c1946c8713L200-R166) [[5]](diffhunk://#diff-25fbc681c498c05676da115974ab1d9e88450a2969e5f0c969b200633ea75a48L141-L146) [[6]](diffhunk://#diff-25fbc681c498c05676da115974ab1d9e88450a2969e5f0c969b200633ea75a48L160-L172)
* Updated the form input for "Branch" to use `doctype="Company"` instead of `doctype="Branch"` for selection, aligning with backend changes.

**Backend and API changes:**

* Changed the `get_branches` API to return companies instead of branches, removing the region mapping and simplifying the data model.
* Updated the membership creation logic in `user.py` to use the "branch" field for both `custom_company` and `company`, replacing previous usage of "region". [[1]](diffhunk://#diff-1d4ba3b652c8d2b43bad6bcf77e396f57f945934e5b6c682b6ed374ec329048aL67-R67) [[2]](diffhunk://#diff-1d4ba3b652c8d2b43bad6bcf77e396f57f945934e5b6c682b6ed374ec329048aL87-R87)

