### PR TITLE
feat(Employee): extract first and last name from job applicant details

### DIFF
--- a/non_profit/non_profit/overrides/client/employee.js
+++ b/non_profit/non_profit/overrides/client/employee.js
@@ -98,6 +98,20 @@ function fetchJobApplicantDetails(frm) {
       }
     );
 
+    if (
+      job_applicant.applicant_name &&
+      !frm.doc.first_name &&
+      !frm.doc.last_name
+    ) {
+      const parts = job_applicant.applicant_name.trim().split(" ");
+      if (parts.length > 1) {
+        update_fields.first_name = parts.slice(0, -1).join(" ");
+        update_fields.last_name = parts.slice(-1).join(" ");
+      } else {
+        update_fields.first_name = parts[0];
+      }
+    }
+
     if (Object.keys(update_fields).length > 0) {
       frm.set_value(update_fields);
     }

--- a/non_profit/non_profit/overrides/client/job_applicant.js
+++ b/non_profit/non_profit/overrides/client/job_applicant.js
@@ -6,7 +6,7 @@ frappe.ui.form.on("Job Applicant", {
         .then((r) => {
           if (r && !r.message.name) {
             frm.add_custom_button(
-              __("Create Employee"),
+              __("Create Volunteer"),
               () => {
                 frappe.route_options = {
                   job_applicant: frm.doc.name,


### PR DESCRIPTION
This pull request introduces improvements to the job applicant workflow in the non-profit client scripts, focusing on better handling of applicant names and updating interface terminology for clarity.

**Applicant Data Handling:**
* Automatically splits `applicant_name` into `first_name` and `last_name` fields when creating an employee, ensuring more accurate data entry if those fields are empty. (`non_profit/non_profit/overrides/client/employee.js`, [non_profit/non_profit/overrides/client/employee.jsR101-R114](diffhunk://#diff-4b338332659d922bacecb7138685cc5ddc8b450a47c7b0f86a9602c4dfaa177aR101-R114))

**UI Terminology Update:**
* Changes the custom button label from "Create Employee" to "Create Volunteer" on the Job Applicant form, reflecting more appropriate terminology for the non-profit context. (`non_profit/non_profit/overrides/client/job_applicant.js`, [non_profit/non_profit/overrides/client/job_applicant.jsL9-R9](diffhunk://#diff-54a8a5764182c99ba507564872de904869d64cf61c03463079d1043367f79fdcL9-R9))