### PR TITLE
Ft/vmms

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -20,6 +20,7 @@ declare module 'vue' {
     AttendEventModal: typeof import('./src/components/Modals/AttendEventModal.vue')['default']
     AudioBlock: typeof import('./src/components/AudioBlock.vue')['default']
     Autocomplete: typeof import('./src/components/Controls/Autocomplete.vue')['default']
+    Availability: typeof import('./src/components/Modals/Availability.vue')['default']
     BadgeAssignmentForm: typeof import('./src/components/Settings/BadgeAssignmentForm.vue')['default']
     BadgeAssignments: typeof import('./src/components/Settings/BadgeAssignments.vue')['default']
     BadgeForm: typeof import('./src/components/Settings/BadgeForm.vue')['default']

--- a/frontend/src/components/EventCalendar.vue
+++ b/frontend/src/components/EventCalendar.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script lang="ts" setup>
-import { Calendar, createResource, toast } from "frappe-ui";
+import { Calendar, toast } from "frappe-ui";
 import { Event } from "./EventCard.vue";
 import { computed, inject, ref } from "vue";
 import AttendEventModal from "./Modals/AttendEventModal.vue";

--- a/frontend/src/components/Modals/Availability.vue
+++ b/frontend/src/components/Modals/Availability.vue
@@ -34,8 +34,6 @@
           }"
           :events="calendarSlots"
         />
-
-        {{ calendarSlots }}
       </div>
     </template>
     <template #actions>
@@ -131,7 +129,7 @@ function getDatesBetween(start: string, end: string) {
   const last = new Date(end);
 
   while (current <= last) {
-    dates.push(new Date(current).toISOString().slice(0, 10)); 
+    dates.push(new Date(current).toISOString().slice(0, 10));
     current.setDate(current.getDate() + 1);
   }
 
@@ -150,10 +148,10 @@ const calendarSlots = computed(() => {
       return {
         title: "Available",
         id: `${slot.name}-${day}`,
-        fromDate: `${day} ${startTime}`, 
-        toDate: `${day} ${endTime}`, 
-        fromTime: `${day} ${startTime}`, 
-        toTime: `${day} ${endTime}`, 
+        fromDate: `${day} ${startTime}`,
+        toDate: `${day} ${endTime}`,
+        fromTime: `${day} ${startTime}`,
+        toTime: `${day} ${endTime}`,
         color: "green",
       };
     });

--- a/frontend/src/components/Modals/Availability.vue
+++ b/frontend/src/components/Modals/Availability.vue
@@ -1,0 +1,162 @@
+<template>
+  <Dialog
+    v-model="setAvailability"
+    :options="{ size: calendarView ? '7xl' : 'lg' }"
+  >
+    <template #body-title>
+      <h3 class="text-xl font-bold text-gray-900">
+        Choose Available Timeslots
+      </h3>
+    </template>
+    <template #body-content>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 p-2">
+        <DateTimePicker
+          v-model="availabilityslot.starts_on"
+          variant="subtle"
+          placeholder="From"
+          label="From"
+        />
+        <DateTimePicker
+          v-model="availabilityslot.ends_on"
+          variant="subtle"
+          placeholder="To"
+          label="To"
+        />
+      </div>
+
+      <div class="p-3" v-if="calendarView">
+        <Calendar
+          :config="{
+            defaultMode: 'Month',
+            eventIcons: {},
+            allowCustomClickEvents: true,
+            enableShortcuts: false,
+          }"
+          :events="calendarSlots"
+        />
+
+        {{ calendarSlots }}
+      </div>
+    </template>
+    <template #actions>
+      <div class="flex flex-row justify-end space-x-2 w-full items-center">
+        <Button
+          variant="outline"
+          theme="red"
+          @click="calendarView = !calendarView"
+        >
+          {{ calendarView ? "Hide" : "Show" }} Calendar Slots
+        </Button>
+        <Button
+          variant="solid"
+          theme="red"
+          :loading="newSlot.loading"
+          @click="validateSlot"
+          class="rounded-xl shadow-md"
+        >
+          Confirm Slots
+        </Button>
+      </div>
+      <ErrorMessage :message="newSlot.error" class="mt-2 text-center" />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import {
+  Dialog,
+  Button,
+  createResource,
+  DateTimePicker,
+  ErrorMessage,
+  Calendar,
+} from "frappe-ui";
+import { computed, reactive, ref, watch } from "vue";
+import { usersStore } from "../../stores/user";
+const { roleResource, presentSlots } = usersStore();
+const setAvailability = ref(true);
+const calendarView = ref(false);
+
+const emit = defineEmits(["success"]);
+
+const availabilityslot = reactive({
+  employee: roleResource.data.employee,
+  company: roleResource.data.company,
+  user: roleResource.data.name,
+  starts_on: "",
+  ends_on: "",
+});
+
+const newSlot = createResource({
+  url: "non_profit.non_profit.api.create_availability_slot",
+  makeParams(values) {
+    return { slot_data: { ...values } };
+  },
+  onSuccess() {
+    availabilityslot.starts_on = "";
+    availabilityslot.ends_on = "";
+
+    emit("success");
+    setAvailability.value = false;
+  },
+});
+
+function validateSlot() {
+  if (availabilityslot.starts_on >= availabilityslot.ends_on) {
+    newSlot.error = "From time must be before To time";
+  }
+
+  if (!availabilityslot.starts_on || !availabilityslot.ends_on) {
+    newSlot.error = "Both From and To times are required";
+  }
+
+  if (!newSlot.error) {
+    newSlot.submit({ ...availabilityslot });
+  }
+}
+
+watch(
+  () => [availabilityslot.starts_on, availabilityslot.ends_on],
+  ([starts_on, ends_on]) => {
+    if (starts_on >= ends_on) {
+      newSlot.error = "From time must be before To time";
+    } else {
+      newSlot.error = "";
+    }
+  }
+);
+function getDatesBetween(start: string, end: string) {
+  const dates: string[] = [];
+  let current = new Date(start);
+  const last = new Date(end);
+
+  while (current <= last) {
+    dates.push(new Date(current).toISOString().slice(0, 10)); 
+    current.setDate(current.getDate() + 1);
+  }
+
+  return dates;
+}
+
+const calendarSlots = computed(() => {
+  if (!presentSlots.data) return [];
+
+  return presentSlots.data.flatMap((slot) => {
+    const days = getDatesBetween(slot.starts_on, slot.ends_on);
+    const startTime = new Date(slot.starts_on).toTimeString().slice(0, 8);
+    const endTime = new Date(slot.ends_on).toTimeString().slice(0, 8);
+
+    return days.map((day) => {
+      return {
+        title: "Available",
+        id: `${slot.name}-${day}`,
+        fromDate: `${day} ${startTime}`, 
+        toDate: `${day} ${endTime}`, 
+        fromTime: `${day} ${startTime}`, 
+        toTime: `${day} ${endTime}`, 
+        color: "green",
+      };
+    });
+  });
+});
+</script>

--- a/frontend/src/components/Volunteer.vue
+++ b/frontend/src/components/Volunteer.vue
@@ -1,31 +1,43 @@
 <template>
   <div>
     <!-- Top Buttons -->
-    <div class="flex flex-row justify-end items-center m-6 space-x-4">
-      <Button
-        variant="solid"
-        size="lg"
-        theme="red"
-        @click="setAvailability = true"
-        class="rounded-xl shadow-md"
-      >
-        Set Availability
-      </Button>
-
-      <!-- Notification Bell -->
+    <div class="flex flex-row justify-end items-center m-6 md:space-x-4">
       <div
-        class="relative cursor-pointer"
-        @click="showNotificationDialog = true"
+        v-if="presentSlots.data && presentSlots.data.length === 0"
+        class="flex items-center justify-center"
       >
-        <div
-          class="relative inline-block"
-          :class="{ 'animate-bounce': hasNotification }"
+        <p
+          class="text-sm border border-blue-600 p-1 bg-blue-100 rounded-lg text-blue-600 font-medium"
         >
-          <Bell class="h-7 w-7 text-gray-700" />
-          <span
-            v-if="hasNotification"
-            class="absolute -top-1 -right-1 block h-3 w-3 rounded-full bg-red-600 ring-2 ring-white"
-          ></span>
+          Action Required: Please set your availability to be deployed.
+        </p>
+      </div>
+      <div class="flex flex-row space-x-4 items-center">
+        <Button
+          variant="solid"
+          size="lg"
+          theme="red"
+          @click="setAvailability = true"
+          class="rounded-xl shadow-md"
+        >
+          Set Availability
+        </Button>
+
+        <!-- Notification Bell -->
+        <div
+          class="relative cursor-pointer"
+          @click="showNotificationDialog = true"
+        >
+          <div
+            class="relative inline-block"
+            :class="{ 'animate-bounce': hasNotification }"
+          >
+            <Bell class="h-7 w-7 text-gray-700" />
+            <span
+              v-if="hasNotification"
+              class="absolute -top-1 -right-1 block h-3 w-3 rounded-full bg-red-600 ring-2 ring-white"
+            ></span>
+          </div>
         </div>
       </div>
     </div>
@@ -188,42 +200,6 @@
     </Dialog>
 
     <!-- Availability Dialog -->
-    <Dialog v-model="setAvailability">
-      <template #body-title>
-        <h3 class="text-xl font-bold text-gray-900">
-          Choose Available Timeslots
-        </h3>
-      </template>
-      <template #body-content>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 p-2">
-          <DateTimePicker
-            v-model="availabilityslot.starts_on"
-            variant="subtle"
-            placeholder="From"
-            label="From"
-          />
-          <DateTimePicker
-            v-model="availabilityslot.ends_on"
-            variant="subtle"
-            placeholder="To"
-            label="To"
-          />
-        </div>
-      </template>
-      <template #actions>
-        <Button
-          v-if="availabilityslot.starts_on && availabilityslot.ends_on"
-          variant="solid"
-          theme="blue"
-          :loading="newSlot.loading"
-          @click="createSlot"
-          class="rounded-xl shadow-md"
-        >
-          Confirm Slots
-        </Button>
-        <ErrorMessage :message="newSlot.error" />
-      </template>
-    </Dialog>
   </div>
 
   <div class="px-10">
@@ -292,20 +268,15 @@
       </router-link>
     </div>
   </div>
+
+  <Availability @success="updateAvailability" v-model="setAvailability" />
 </template>
 
 <script lang="ts" setup>
-import { reactive, ref } from "vue";
-import {
-  Dialog,
-  Button,
-  createResource,
-  DateTimePicker,
-  ErrorMessage,
-  Badge,
-  Card,
-} from "frappe-ui";
-import { Bell } from "lucide-vue-next";
+import { ref } from "vue";
+import { Dialog, Button, createResource, Badge, toast } from "frappe-ui";
+import { Bell, LucideCalendar } from "lucide-vue-next";
+import Availability from "./Modals/Availability.vue";
 import { usersStore } from "../stores/user";
 
 interface Task {
@@ -341,21 +312,13 @@ const props = defineProps<{
   rejected_projects: number;
 }>();
 
-const { roleResource } = usersStore();
-
 const hasNotification = ref(false);
 const showNotificationDialog = ref(false);
 const setAvailability = ref(false);
 
 const assignedProjects = ref<Project[]>([]);
 
-const availabilityslot = reactive({
-  employee: roleResource.data.employee,
-  company: roleResource.data.company,
-  user: roleResource.data.name,
-  starts_on: "",
-  ends_on: "",
-});
+const { presentSlots } = usersStore();
 
 const assignmentDecision = createResource({
   url: "non_profit.non_profit.api.accept_assignment",
@@ -398,41 +361,6 @@ const rejectAssignment = (project: Project) => {
   );
 };
 
-const newSlot = createResource({
-  url: "non_profit.non_profit.api.create_availability_slot",
-  makeParams(values) {
-    return { slot_data: values };
-  },
-});
-
-const project = createResource({
-  url: "non_profit.non_profit.api.fetch_assigned_projects",
-  auto: true,
-  onSuccess(data) {
-    if (data.length) {
-      hasNotification.value = true;
-      assignedProjects.value = Array.isArray(data) ? data : [data];
-    } else {
-      hasNotification.value = false;
-    }
-  },
-});
-
-const createSlot = () => {
-  newSlot.submit(
-    { doctype: "Volunteer Availability Slot", ...availabilityslot },
-    {
-      onSuccess(data) {
-        setAvailability.value = false;
-        console.log("submitted", data);
-      },
-      onError(err) {
-        console.log("err", err);
-      },
-    }
-  );
-};
-
 // Priority theme
 function priorityTheme(priority: string) {
   switch (priority) {
@@ -445,5 +373,11 @@ function priorityTheme(priority: string) {
     default:
       return "gray";
   }
+}
+
+function updateAvailability() {
+  setAvailability.value = false;
+  presentSlots.reload();
+  toast.success("Availability updated successfully");
 }
 </script>

--- a/frontend/src/stores/user.js
+++ b/frontend/src/stores/user.js
@@ -26,9 +26,16 @@ export const usersStore = defineStore("lms-users", () => {
     cache: ["roles"],
   });
 
+  const presentSlots = createResource({
+    url: "non_profit.non_profit.api.get_availability_slots",
+    cache: "availability_slots",
+    auto: true,
+  });
+
   return {
     userResource,
     allUsers,
     roleResource,
+    presentSlots,
   };
 });

--- a/non_profit/non_profit/api.py
+++ b/non_profit/non_profit/api.py
@@ -684,13 +684,9 @@ def generate_language_code(language_name):
     return base_code + suffix
 
 
-
-
-
 @frappe.whitelist(allow_guest=True)
 def get_branches():
     return frappe.get_all("Company", filters={"is_group": 0})
-
 
 
 @frappe.whitelist(allow_guest=True)
@@ -903,18 +899,58 @@ def get_projects():
 def create_availability_slot(slot_data):
 
     try:
+        # Prevent duplicate slots
+        if frappe.db.exists(
+            "Volunteer Availability Slot",
+            {
+                "employee": slot_data.get("employee"),
+                "starts_on": slot_data.get("starts_on"),
+                "ends_on": slot_data.get("ends_on"),
+            },
+        ):
+            frappe.throw("You have already created this availability slot")
+
+        employee = slot_data.get("employee")
+        starts_on = slot_data.get("starts_on")
+        ends_on = slot_data.get("ends_on")
+
+        conflict_slots = frappe.db.get_all(
+            "Volunteer Availability Slot",
+            filters={
+                "employee": employee,
+                "starts_on": ["<", ends_on],
+                "ends_on": [">", starts_on],
+            },
+            fields=["name", "starts_on", "ends_on"],
+        )
+        if conflict_slots:
+            frappe.throw(
+                "This slot conflicts with an existing availability slot. Please choose a different time range and check Calendar for existing slots.",
+            )
 
         doc = frappe.get_doc({"doctype": "Volunteer Availability Slot", **slot_data})
 
         doc.insert(ignore_permissions=True)
 
         frappe.db.commit()
-        return {"success": True, "name": doc.name, "data": doc.as_dict()}
 
     except Exception as e:
         frappe.log_error(frappe.get_traceback(), "Availability Slot Creation Error")
 
         frappe.throw("Availability Slot Creation Error")
+
+
+@frappe.whitelist()
+def get_availability_slots():
+    user = get_user_info().get("employee")
+
+    slots = frappe.db.get_all(
+        "Volunteer Availability Slot",
+        filters={"employee": user},
+        fields=["name","starts_on", "ends_on"],
+    )
+
+    return slots
 
 
 @frappe.whitelist()


### PR DESCRIPTION
This pull request introduces a new system for managing volunteer availability slots, including both frontend and backend changes. The main improvements are the addition of a dedicated modal for setting availability, enhanced validation and conflict detection for time slots, and a calendar view to visualize existing slots. The codebase is simplified by moving slot logic into a reusable component and centralizing slot data management.

**Frontend Enhancements:**

* Added a new `Availability` modal component (`Modals/Availability.vue`) for volunteers to select and confirm available timeslots, with calendar visualization and improved validation.
* Updated `Volunteer.vue` to use the new `Availability` modal, removed old inline slot logic, and display an action-required message if no slots are set. [[1]](diffhunk://#diff-1a663e85f60f579183c3474394836f364e5404d163141ddeb1bcc9b5f89e2a83L4-R15) [[2]](diffhunk://#diff-1a663e85f60f579183c3474394836f364e5404d163141ddeb1bcc9b5f89e2a83L191-L226) [[3]](diffhunk://#diff-1a663e85f60f579183c3474394836f364e5404d163141ddeb1bcc9b5f89e2a83R271-R279)
* Centralized slot data fetching in the user store (`usersStore`) and replaced direct slot management with the new `presentSlots` resource.

**Backend Improvements:**

* Enhanced the `create_availability_slot` API to prevent duplicate and conflicting slots, providing clear error messages for volunteers.
* Added a new `get_availability_slots` API endpoint to retrieve all availability slots for the current user, supporting the calendar view in the frontend.

**Codebase Simplification:**

* Removed unused imports and redundant slot management logic from `EventCalendar.vue` and `Volunteer.vue`. [[1]](diffhunk://#diff-0ac1957d3c1e97f07f66dbeba4d583a86fa82982298400633283cbf8bbea0f5bL25-R25) [[2]](diffhunk://#diff-1a663e85f60f579183c3474394836f364e5404d163141ddeb1bcc9b5f89e2a83L344-R321) [[3]](diffhunk://#diff-1a663e85f60f579183c3474394836f364e5404d163141ddeb1bcc9b5f89e2a83L401-L435)
<img width="1238" height="722" alt="image" src="https://github.com/user-attachments/assets/2dd5e6ce-2c10-44a2-8653-86a2f36f82e9" />
<img width="765" height="263" alt="image" src="https://github.com/user-attachments/assets/36ffc6c6-1b47-4443-b22c-fb0868472567" />

<img width="1273" height="624" alt="image" src="https://github.com/user-attachments/assets/e021ff74-c393-48bd-b2a2-74992d2ea034" />


prevent duplication  or concurrent timeslots:
<img width="705" height="372" alt="image" src="https://github.com/user-attachments/assets/79797bc6-d854-4264-b49e-ea9a13c92c56" />

