### PR TITLE
feat(personnel_deployment): add contract creation from assignments

### DIFF
--- a/non_profit/non_profit/doctype/personnel_deployment_assignment/personnel_deployment_assignment.js
+++ b/non_profit/non_profit/doctype/personnel_deployment_assignment/personnel_deployment_assignment.js
@@ -1,8 +1,34 @@
 // Copyright (c) 2025, Frappe and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Personnel Deployment Assignment", {
-// 	refresh(frm) {
+frappe.ui.form.on("Personnel Deployment Assignment", {
+  refresh(frm) {
+    if (!frm.is_new() && frm.doc.require_contract_before_deployment) {
+      frappe.db.get_value(
+        "Contract",
+        {
+          personnel_deployment_assignment: frm.doc.name,
+          docstatus: ["!=", 2],
+        },
+        ["name"],
+        (r) => {
+          if (r && !r.name) {
+            frm.add_custom_button(__("Create Contract"), () => {
+              frappe.model.with_doctype("Contract", () => {
+                let contract = frappe.model.get_new_doc("Contract");
+                contract.party_type = "Employee";
+                contract.party_name = frm.doc.employee;
+                contract.start_date = frm.doc.expected_start_date;
+                contract.end_date = frm.doc.expected_end_date;
+                contract.personnel_deployment_assignment = frm.doc.name;
+                contract.personnel_deployment_request = frm.doc.deployment;
 
-// 	},
-// });
+                frappe.set_route("Form", "Contract", contract.name);
+              });
+            });
+          }
+        }
+      );
+    }
+  },
+});


### PR DESCRIPTION
Adds a contract creation button to Personnel Deployment Assignments:

- Visible only when contracts are required and no active contract exists
- Pre-fills new contract with employee party details, deployment start/end dates,
  and references to the deployment assignment and request

This streamlines the workflow by enabling direct contract creation from
deployment assignments when required.