### PR TITLE
feat(personnel_details_update): remove 'amended_from' field

### DIFF
--- a/non_profit/non_profit/doctype/personnel_details_update/personnel_details_update.json
+++ b/non_profit/non_profit/doctype/personnel_details_update/personnel_details_update.json
@@ -13,8 +13,7 @@
   "date",
   "company",
   "details_section",
-  "update_details",
-  "amended_from"
+  "update_details"
  ],
  "fields": [
   {
@@ -67,21 +66,11 @@
    "fieldname": "update_details",
    "fieldtype": "Table",
    "options": "Employee Property History"
-  },
-  {
-   "fieldname": "amended_from",
-   "fieldtype": "Link",
-   "label": "Amended From",
-   "no_copy": 1,
-   "options": "Employee Details Update",
-   "print_hide": 1,
-   "read_only": 1,
-   "search_index": 1
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-19 12:20:03.485241",
+ "modified": "2025-09-19 14:13:44.286516",
  "modified_by": "Administrator",
  "module": "Non Profit",
  "name": "Personnel Details Update",


### PR DESCRIPTION
This pull request simplifies the `personnel_details_update` DocType definition by removing the `amended_from` field, which previously allowed tracking amendments to employee detail updates. The change streamlines the schema and the form fields.

Schema and field definition updates:

* Removed the `amended_from` field from the `fields` array in `personnel_details_update.json`, eliminating the ability to link to previous amendments.
* Removed `amended_from` from the list of DocType fields, reflecting the field's deletion in the schema.