### PR TITLE
fix: update userResource URL to correct API endpoint

### DIFF
--- a/frontend/src/stores/user.js
+++ b/frontend/src/stores/user.js
@@ -6,7 +6,7 @@ const router = useRouter();
 
 export const usersStore = defineStore("lms-users", () => {
   let userResource = createResource({
-    url: "lms.lms.api.get_user_info",
+    url: "non_profit.non_profit.api.get_user_info",
     onError(error) {
       if (error && error.exc_type === "AuthenticationError") {
         router.push("/login");


### PR DESCRIPTION
This pull request updates the API endpoint used to fetch user information in the `usersStore`. The change ensures that the store now retrieves user data from the correct service.

API endpoint update:

* Changed the `url` in the `userResource` definition from `"lms.lms.api.get_user_info"` to `"non_profit.non_profit.api.get_user_info"` in `frontend/src/stores/user.js`, ensuring user info is fetched from the non-profit service.