### PR TITLE
refactor: remove inline CSRF token script from index.html

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,9 +8,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script>
-      window.csrf_token = "{{ frappe.session.csrf_token }}";
-    </script>
 
     <script type="module" src="/src/main.js"></script>
   </body>


### PR DESCRIPTION
This pull request includes a small change to the `frontend/index.html` file, removing the inline script that set the `csrf_token` on the `window` object.