### PR TITLE
Ft/vmms

### DIFF
--- a/frontend/src/components/MemberPlan.vue
+++ b/frontend/src/components/MemberPlan.vue
@@ -69,7 +69,12 @@
 
         <!-- CTA Footer -->
         <div class="bg-gray-50 p-4 border-t">
-          <Button :variant="'solid'" theme="red" class="w-full">
+          <Button
+            :variant="'solid'"
+            theme="red"
+            class="w-full"
+            @click="payNow = true"
+          >
             Renew Membership
           </Button>
         </div>
@@ -114,15 +119,42 @@
       </RouterLink>
     </div>
   </div>
+  <Dialog v-model="payNow">
+    <template #body-title>
+      <h3 class="text-2xl text-gray-900">
+        <span class="text-red-600">Enter Mpesa Phone Number to Pay</span>
+      </h3>
+    </template>
+
+    <template #body-content>
+      <form @submit.prevent="renewMembership" class="space-y-6">
+        <FormControl
+          :type="'password'"
+          :ref_for="true"
+          size="sm"
+          variant="subtle"
+                    placeholder="+254123456789"
+
+          :disabled="false"
+          label="Phone Number"
+          v-model="phoneNumber"
+        />
+      </form>
+    </template>
+  </Dialog>
 </template>
 
 <script lang="ts" setup>
-import { Badge, Card, createResource } from "frappe-ui";
+import { Badge, Card, createResource, Dialog, FormControl } from "frappe-ui";
 import Button from "frappe-ui/src/components/Button/Button.vue";
 import { RouterLink } from "vue-router";
 import { usersStore } from "../stores/user";
+import { ref } from "vue";
 
 const { roleResource } = usersStore();
+
+const payNow = ref(false);
+const phoneNumber = ref("");
 
 interface Membership {
   name?: string;
@@ -164,5 +196,11 @@ function formatDate(dateStr?: string): string {
     month: "short",
     year: "numeric",
   });
+}
+
+function renewMembership() {
+  // Logic to renew membership
+  console.log("Renewing membership with phone number:", phoneNumber.value);
+  
 }
 </script>

--- a/frontend/src/pages/Membership.vue
+++ b/frontend/src/pages/Membership.vue
@@ -46,7 +46,12 @@
       <div></div>
     </template>
 
-    <Dialog v-model="registerDialog">
+    <Dialog
+      v-model="registerDialog"
+      :options="{
+        size: 'xl',
+      }"
+    >
       <template #body-title>
         <h3 class="text-2xl font-bold text-gray-900">
           Register as a <span class="text-red-600">Member</span>
@@ -70,6 +75,7 @@
               :filters="{ is_group: 0 }"
               v-model="membershipForm.branch"
               class="w-full"
+              :readonly="payNow"
             />
           </div>
 
@@ -87,15 +93,16 @@
             </p>
           </div>
 
-          <!-- Error -->
           <ErrorMessage
-            v-if="createMembership.error"
+            v-if="!payNow && createMembership.error"
             class="text-center border rounded-md p-2 border-red-500 bg-red-50 text-sm"
             :message="createMembership.error"
           />
 
-          <!-- Actions -->
-          <div class="flex flex-col sm:flex-row justify-end gap-3 pt-2">
+          <div
+            v-if="!payNow"
+            class="flex flex-col sm:flex-row justify-end gap-3 pt-2"
+          >
             <Button
               type="button"
               variant="outline"
@@ -115,18 +122,54 @@
             >
               Register
             </Button>
-
-            <!-- Pay Now Button -->
-            <Button
-              type="button"
-              variant="solid"
-              theme="red"
-              icon-right="credit-card"
-              class="rounded-lg px-6"
-              @click="payNow"
+          </div>
+          <div v-if="payNow" class="space-y-4">
+            <span
+              class="text-center border rounded-md p-2 mb-10 border-blue-500 bg-blue-50 text-sm"
             >
-              Pay Now
-            </Button>
+              Registration successful! Please proceed to pay for your membership
+              below.
+            </span>
+
+            <Input
+              :type="'text'"
+              :ref_for="true"
+              size="sm"
+              variant="subtle"
+              placeholder="+254123456789"
+              :disabled="false"
+              label="Enter Mpesa Phone Number to Pay"
+              v-model="membershipForm.phone_number"
+              required
+            />
+
+            <ErrorMessage
+              v-if="createMembership.error"
+              class="text-center border rounded-md p-2 border-red-500 bg-red-50 text-sm"
+              :message="createMembership.error"
+            />
+
+            <div class="flex flex-col sm:flex-row justify-end gap-3 pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                theme="red"
+                class="rounded-lg px-5"
+                @click="cleanUpMembershipForm"
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="solid"
+                theme="red"
+                icon-right="credit-card"
+                class="rounded-lg px-6"
+                @click="payMembership"
+              >
+                Pay Now
+              </Button>
+            </div>
           </div>
         </form>
       </template>
@@ -135,9 +178,16 @@
 </template>
 
 <script lang="ts" setup>
-import { inject, reactive, ref } from "vue";
+import { inject, reactive, ref, watch } from "vue";
 import { membershipStore } from "../stores/membership";
-import { Dialog, Button, createResource, ErrorMessage, toast } from "frappe-ui";
+import {
+  Dialog,
+  Button,
+  createResource,
+  ErrorMessage,
+  toast,
+  Input,
+} from "frappe-ui";
 import Member from "../components/MemberPlan.vue";
 import EmptyState from "../components/EmptyState.vue";
 import Link from "../components/Controls/Link.vue";
@@ -147,13 +197,14 @@ const { membershipTypes, currentMembership } = membershipStore();
 const user = inject<any>("$user");
 
 const registerDialog = ref(false);
-
+const payNow = ref(false);
 const membershipForm = reactive({
   membership_type: "",
   amount: 0,
   branch: "",
   member_name: user.data ? user.data.full_name : "",
   email_id: user.data ? user.data.email : "",
+  phone_number: "",
 });
 
 const createMembership = createResource({
@@ -162,7 +213,7 @@ const createMembership = createResource({
     toast.success("Membership created successfully");
     currentMembership.reload();
     membershipTypes.reload();
-    cleanUpMembershipForm();
+    payNow.value = true;
   },
 });
 
@@ -171,6 +222,8 @@ function cleanUpMembershipForm() {
   membershipForm.membership_type = "";
   membershipForm.amount = 0;
   membershipForm.branch = "";
+  membershipForm.phone_number = "";
+  payNow.value = false;
   createMembership.error = "";
 }
 
@@ -188,5 +241,32 @@ function submit() {
   createMembership.submit({ ...membershipForm });
 }
 
-function payNow() {}
+function payMembership() {
+  if (!membershipForm.phone_number) {
+    createMembership.error = "Please enter your phone number";
+    return;
+  }
+
+  if (!isValidPhone(membershipForm.phone_number)) {
+    createMembership.error =
+      "Please enter a valid Kenyan phone number.eg. (+254123456789)";
+    return;
+  }
+  createMembership.error = "";
+  // Logic to pay membership
+  alert(
+    `Paying for membership with phone number: ${membershipForm.phone_number}`
+  );
+}
+
+function isValidPhone(phone: string) {
+  const regex = /^\+254\d{9}$/;
+  return regex.test(phone);
+}
+
+watch(registerDialog, (newValue) => {
+  if (newValue === false) {
+    cleanUpMembershipForm();
+  }
+});
 </script>


### PR DESCRIPTION
This pull request introduces a new payment flow for membership renewal and registration, focusing on collecting and validating Mpesa phone numbers before proceeding with payment. The changes enhance the user experience by adding dialogs for phone number entry, improving form validation, and streamlining the payment process after registration.

### Membership Renewal Flow Enhancements
* Added a dialog to `MemberPlan.vue` that prompts users to enter their Mpesa phone number when renewing membership, including a form and a new `renewMembership` function for handling the process. [[1]](diffhunk://#diff-a8cc944fe913bf7103d9126f2c2d1d6afdc1d537886c1203a0541aabccb0fe9eL72-R77) [[2]](diffhunk://#diff-a8cc944fe913bf7103d9126f2c2d1d6afdc1d537886c1203a0541aabccb0fe9eR122-R158) [[3]](diffhunk://#diff-a8cc944fe913bf7103d9126f2c2d1d6afdc1d537886c1203a0541aabccb0fe9eR200-R205)

### Membership Registration Flow Improvements
* Updated the registration dialog in `Membership.vue` to show a phone number entry and payment section after successful registration, including input validation and error handling for Kenyan phone numbers. [[1]](diffhunk://#diff-ab0f64eb48db31830aa203bebb51c02f1cdce469e6ab310b005a08c1946c8713R125-R190) [[2]](diffhunk://#diff-ab0f64eb48db31830aa203bebb51c02f1cdce469e6ab310b005a08c1946c8713L150-R207) [[3]](diffhunk://#diff-ab0f64eb48db31830aa203bebb51c02f1cdce469e6ab310b005a08c1946c8713L191-R271)

### UI and Form Logic Updates
* Made the branch selector read-only and hid error and action sections when the payment flow is active, improving conditional rendering and user guidance during registration. [[1]](diffhunk://#diff-ab0f64eb48db31830aa203bebb51c02f1cdce469e6ab310b005a08c1946c8713R78) [[2]](diffhunk://#diff-ab0f64eb48db31830aa203bebb51c02f1cdce469e6ab310b005a08c1946c8713L90-R105)
* Added dialog sizing options for better UI presentation during registration.

### State Management and Cleanup
* Enhanced form cleanup logic to reset the phone number and payment state when dialogs are closed or cancelled, ensuring a consistent user experience. [[1]](diffhunk://#diff-ab0f64eb48db31830aa203bebb51c02f1cdce469e6ab310b005a08c1946c8713R225-R226) [[2]](diffhunk://#diff-ab0f64eb48db31830aa203bebb51c02f1cdce469e6ab310b005a08c1946c8713L165-R216)
<img width="691" height="485" alt="Screenshot from 2025-09-29 17-40-32" src="https://github.com/user-attachments/assets/1206e160-541a-4d06-a424-43d10178d043" />

<img width="724" height="535" alt="image" src="https://github.com/user-attachments/assets/19455458-94d2-49cb-913b-29069a44c31b" />

