### PR TITLE
feat(Login): add 'Forgot Password?' button with navigation to reset page

### DIFF
--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -39,6 +39,11 @@
               @click="passWordVisible = !passWordVisible"
             />
           </div>
+          <button @click="forgotPassword">
+            <span class="text-sm text-right text-red-600 hover:underline"
+              >Forgot Password?</span
+            >
+          </button>
         </template>
 
         <template v-else>
@@ -230,5 +235,9 @@ function submit() {
       ...signUpForm,
     });
   }
+}
+
+function forgotPassword() {
+  window.location.href = "/login#forgot";
 }
 </script>

--- a/frontend/src/pages/Membership.vue
+++ b/frontend/src/pages/Membership.vue
@@ -123,9 +123,9 @@
               Register
             </Button>
           </div>
-          <div v-if="payNow" class="space-y-4">
+          <div v-if="payNow" class="flex flex-col space-y-4">
             <span
-              class="text-center border rounded-md p-2 mb-10 border-blue-500 bg-blue-50 text-sm"
+              class="text-center text-blue-800 border rounded-md p-2 border-blue-500 bg-blue-50 text-sm"
             >
               Registration successful! Please proceed to pay for your membership
               below.


### PR DESCRIPTION
This pull request introduces a minor UI improvement to the login page and a small style adjustment to the membership registration flow. The most important changes are the addition of a "Forgot Password?" button to the login form and a visual enhancement to the membership registration success message.

**Login page enhancements:**

* Added a "Forgot Password?" button to the login form, which navigates users to the password recovery flow when clicked. [[1]](diffhunk://#diff-25fbc681c498c05676da115974ab1d9e88450a2969e5f0c969b200633ea75a48R42-R46) [[2]](diffhunk://#diff-25fbc681c498c05676da115974ab1d9e88450a2969e5f0c969b200633ea75a48R239-R242)
