### PR TITLE
Ft/vmms

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <FrappeUIProvider>
     <Layout>
-      <div class="text-base">
+      <div class="text-base md:max-w-7xl md:mx-auto">
         <router-view />
       </div>
     </Layout>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <FrappeUIProvider>
     <Layout>
-      <div class="text-base md:max-w-7xl md:mx-auto">
+      <div class="text-base">
         <router-view />
       </div>
     </Layout>

--- a/frontend/src/components/DesktopLayout.vue
+++ b/frontend/src/components/DesktopLayout.vue
@@ -1,19 +1,19 @@
 <template>
-	<div class="relative flex h-full flex-col">
-		<div class="h-full flex-1">
-			<div class="flex h-screen text-base bg-surface-white">
-				<div
-					class="relative block min-h-0 flex-shrink-0 overflow-hidden hover:overflow-auto"
-				>
-					<AppSidebar />
-				</div>
-				<div class="w-full overflow-auto" id="scrollContainer">
-					<slot />
-				</div>
-			</div>
-		</div>
-	</div>
+  <div class="relative flex h-full flex-col">
+    <div class="h-full flex-1">
+      <div class="flex h-screen text-base bg-surface-white">
+        <div
+          class="relative block min-h-0 flex-shrink-0 overflow-hidden hover:overflow-auto"
+        >
+          <AppSidebar />
+        </div>
+        <div class="w-full overflow-auto mx-auto px-8" id="scrollContainer">
+          <slot />
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 <script setup>
-import AppSidebar from './AppSidebar.vue'
+import AppSidebar from "./AppSidebar.vue";
 </script>

--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -16,7 +16,7 @@
       {{ "Login to View Dashboard" }}
     </Button>
   </div>
-  <div v-if="user?.data">
+  <div v-if="user?.data" class="max-w-7xl mx-auto">
     <div class="flex flex-col">
       <h1 class="text-3xl font-bold px-4 mt-5">
         Welcome, {{ user?.data?.full_name }}

--- a/frontend/src/pages/Events.vue
+++ b/frontend/src/pages/Events.vue
@@ -1,13 +1,17 @@
 <template>
   <div class="p-5">
-    <header class="flex justify-between items-center mt-5">
-      <h1 class="text-3xl">Events</h1>
+    <header
+      class="flex justify-between items-center mt-5 md:max-w-7xl md:mx-auto"
+    >
+      <h1 class="text-3xl font-bold">Events</h1>
       <Button variant="solid" theme="red" @click="toggleEventViews">
         {{ toggleEventView ? "List" : "Calendar" }} View</Button
       >
     </header>
   </div>
-  <div class="p-8 grid grid-cols-1 lg:grid-cols-3 gap-4">
+  <div
+    class="md:max-w-7xl md:mx-auto p-8 grid grid-cols-1 lg:grid-cols-3 gap-4"
+  >
     <EventCard
       v-if="!toggleEventView"
       v-for="event in events.data"

--- a/frontend/src/pages/Membership.vue
+++ b/frontend/src/pages/Membership.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="space-y-4 max-w-7xl mx-auto px-4">
+  <div class="space-y-4 mx-auto px-4">
     <ProgressSpinner
       v-if="currentMembership.loading || membershipTypes.loading"
       class="mt-6"
@@ -127,7 +127,7 @@
             <span
               class="text-center text-blue-800 border rounded-md p-2 border-blue-500 bg-blue-50 text-sm"
             >
-              Registration successful! Please proceed to pay for your membership
+              Registration Initiated! Please proceed to pay for your membership
               below.
             </span>
 

--- a/non_profit/non_profit/api.py
+++ b/non_profit/non_profit/api.py
@@ -268,7 +268,7 @@ def get_membership_types():
     memberships = frappe.get_all(
         "Membership Type",
         fields=["name", "membership_type", "amount"],
-        order_by="amount desc",
+        order_by="amount asc",
     )
     for membership in memberships:
         membership_benefits = frappe.get_all(


### PR DESCRIPTION
This pull request introduces several UI and backend improvements focused on layout consistency, user experience, and data ordering. The most significant updates include standardizing maximum width and centering across multiple pages, refining event and dashboard layouts, updating messaging for membership registration, and correcting the membership type ordering in the backend.

**Frontend layout and styling improvements:**

* Standardized maximum width (`max-w-7xl`) and centered content (`mx-auto`) for the main content area in `DesktopLayout.vue`, `Dashboard.vue`, and `Events.vue` to improve visual consistency across pages. (`[[1]]
* Updated the `Events.vue` header and event card container to use bold headings and consistent spacing, enhancing readability and layout alignment. 
* Removed the `max-w-7xl` constraint from the main container in `Membership.vue` to allow more flexible layout, but retained centering and padding. 

**User messaging improvements:**

* Changed the membership registration success message in `Membership.vue` to "Registration Initiated! Please proceed to pay for your membership below." for clearer user guidance. 

**Backend data ordering fix:**

* Corrected the ordering of membership types in the API (`api.py`) from descending to ascending by amount, ensuring membership types are listed from lowest to highest price. 
This pull request primarily focuses on improving layout consistency and user experience across several frontend pages, along with a minor backend update to membership type ordering. The most significant changes include standardizing maximum width and centering on key pages, refining UI text, and adjusting the order of membership types returned by the API.

**Frontend layout improvements:**

* Added consistent maximum width and horizontal centering (`max-w-7xl mx-auto`) to the main content containers in `Dashboard.vue`, `Events.vue`, and the scrollable area in `DesktopLayout.vue` for better alignment and readability. [[1]]
* Updated the header and event card grid in `Events.vue` to use bold text and improved spacing, enhancing visual hierarchy.

**UI text and feedback refinement:**

* Changed the registration success message in `Membership.vue` to "Registration Initiated! Please proceed to pay for your membership below." for clearer user guidance.

**Backend membership logic:**

* Modified the membership types API in `non_profit/api.py` to return membership types in ascending order of amount, rather than descending, ensuring lower-cost memberships appear first.

**Other layout adjustments:**

* Removed the maximum width constraint from the outer container in `Membership.vue`, possibly to allow for more flexible layouts.