### PR TITLE
Ft/vmms

### DIFF
--- a/frontend/src/components/Modals/AttendEventModal.vue
+++ b/frontend/src/components/Modals/AttendEventModal.vue
@@ -1,104 +1,139 @@
 <template>
   <Dialog v-model="isOpen">
     <template #body-title>
-      <h3 class="text-xl font-medium text-gray-900">Event Details</h3>
+      <div class="flex items-center gap-2">
+        <CalendarCheck class="w-6 h-6 text-green-600" />
+        <h3 class="text-xl font-semibold text-gray-900">
+          Confirm Your Attendance
+        </h3>
+      </div>
     </template>
 
     <template #body-content>
-      <div v-if="event" class="space-y-4">
-        <h4 class="text-lg font-semibold text-gray-800">
-          {{ event.subject }}
-        </h4>
+      <div class="space-y-4">
+        <p class="text-gray-700">
+          You're about to register for this event. Once confirmed, you'll
+          receive:
+        </p>
 
-        <div v-if="event.description" class="bg-gray-50 rounded-lg p-3">
-          <p class="text-sm text-gray-600">{{ event.description }}</p>
+        <div
+          class="bg-green-50 border border-green-100 rounded-lg p-4 space-y-2"
+        >
+          <div class="flex items-start gap-3">
+            <Check class="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" />
+            <span class="text-sm text-gray-700">
+              <span class="font-semibold">Confirmation email</span> with event
+              details
+            </span>
+          </div>
         </div>
 
-        <div class="grid gap-2 text-sm">
-          <div class="flex justify-between">
-            <span class="font-medium">Start</span>
-            <span>{{ event.starts_on }}</span>
-          </div>
-          <div class="flex justify-between">
-            <span class="font-medium">End</span>
-            <span>{{ event.ends_on }}</span>
-          </div>
-          <div class="flex justify-between">
-            <span class="font-medium">Status</span>
-            <Badge
-              :variant="event.confirmStatus ? 'subtle' : 'outline'"
-              :theme="event.confirmStatus ? 'green' : 'red'"
-              size="sm"
-            >
-              {{ event.confirmStatus ? "Confirmed" : "Not Confirmed" }}
-            </Badge>
-          </div>
+        <div class="bg-red-50 border border-red-100 rounded-lg p-3">
+          <p class="text-sm text-gray-700">
+            <span class="font-semibold text-red-900">📅 Important:</span>
+            Make sure to mark your calendar and arrive on time!
+          </p>
         </div>
+      </div>
+
+      <div
+        class="border p-2 mt-3 rounded-lg space-y-2"
+        v-if="user.data === 'Guest'"
+      >
+        <span>Please fill out the following information:</span>
+        <form action="" @submit.prevent="submit">
+          <Input
+            required
+            name="first_name"
+            type="text"
+            placeholder="John"
+            label="First Name"
+            v-model="attendData.first_name"
+          />
+
+          <Input
+            required
+            name="last_name"
+            type="text"
+            placeholder="Doe"
+            label="Last Name"
+            v-model="attendData.last_name"
+          />
+
+          <Input
+            required
+            name="email"
+            type="email"
+            placeholder="johndoe@email.com"
+            label="Email"
+            v-model="attendData.email"
+          />
+
+          <Input
+            required
+            name="phone"
+            type="text"
+            placeholder="+254712345678"
+            label="Phone Number"
+            v-model="attendData.phone"
+          />
+        </form>
       </div>
     </template>
 
-    <template #actions>
-      <div class="flex space-x-2 justify-end">
-        <Button variant="outline" theme="gray" size="sm" @click="close">
-          Close
-        </Button>
-        <Button
-          v-if="event && !event.confirmStatus"
-          variant="solid"
-          theme="red"
-          size="sm"
-          :loading="confirmEvent.loading"
-          @click="submit(event)"
-        >
-          Confirm Attendance
-        </Button>
+    <template #actions="{ close }">
+      <div class="space-y-3">
+        <div class="flex space-x-2 justify-end">
+          <Button variant="outline" theme="gray" size="sm" @click="close">
+            Cancel
+          </Button>
+          <Button
+            variant="solid"
+            theme="green"
+            size="sm"
+            @click="submit"
+            :loading="confirmEvent.loading"
+          >
+            <span class="flex items-center gap-2">
+              <Check class="w-4 h-4" />
+              Confirm Attendance
+            </span>
+          </Button>
+        </div>
+        <ErrorMessage
+          v-if="confirmEvent.error"
+          :message="confirmEvent.error"
+          class="text-center border border-red-400 rounded-md p-2"
+        />
       </div>
-      <ErrorMessage :message="confirmEvent.error"  class="text-center mt-2 border border-red-400 rounded-md p-2" />
     </template>
   </Dialog>
 </template>
 
 <script lang="ts" setup>
-import {
-  Badge,
-  Button,
-  Dialog,
-  ErrorMessage,
-  createResource,
-  toast,
-} from "frappe-ui";
-import { computed } from "vue";
-import type { Event } from "../EventCard.vue";
+import { Button, Dialog, ErrorMessage, createResource, Input } from "frappe-ui";
+import { CalendarCheck, Check } from "lucide-vue-next";
+import { inject, reactive, ref } from "vue";
 
-const props = defineProps<{
-  modelValue: boolean;
-  event: Event | null;
-}>();
+const isOpen = ref(false);
+const user = inject<any>("$user");
 
-const emit = defineEmits<{
-  (e: "update:modelValue", value: boolean): void;
-  (e: "confirmed"): void;
-}>();
-
-const isOpen = computed({
-  get: () => props.modelValue,
-  set: (val: boolean) => emit("update:modelValue", val),
+const attendData = reactive({
+  event: "",
+  first_name: user.data !== "Guest" ? user.data.first_name : "",
+  last_name: user.data !== "Guest" ? user.data.last_name : "",
+  phone: user.data !== "Guest" ? user.data.phone : "",
+  email: user.data !== "Guest" ? user.data.email : "",
 });
-
-function close() {
-  isOpen.value = false;
-  confirmEvent.reset();
-}
 
 const confirmEvent = createResource({
   url: "non_profit.non_profit.api.attend_event",
   onSuccess() {
     isOpen.value = false;
-    emit("confirmed");
   },
 });
 
 function submit(event: Event) {
-  confirmEvent.submit({ ...event });
+  alert("Registration functionality to be implemented.");
 }
 </script>

--- a/frontend/src/pages/EventDetail.vue
+++ b/frontend/src/pages/EventDetail.vue
@@ -213,6 +213,7 @@
       </div>
     </div>
   </div>
+  <AttendEventModal v-model="isOpen" />
 </template>
 <script setup>
 import { Button, createResource, toast } from "frappe-ui";
@@ -231,10 +232,12 @@ import {
   Youtube,
 } from "lucide-vue-next";
 import router from "../router";
+import AttendEventModal from "../components/Modals/AttendEventModal.vue";
 
 const route = useRoute();
 const eventName = ref(route.params.id);
 const user = inject("$user");
+const isOpen = ref(false);
 
 const eventDetail = createResource({
   url: "non_profit.non_profit.api.get_event_details",
@@ -298,7 +301,7 @@ const formatDate = (dateStr) => {
 };
 
 const handleRegister = () => {
-  alert("Registration functionality to be implemented.");
+  isOpen.value = true;
 };
 
 onMounted(() => {

--- a/non_profit/non_profit/api.py
+++ b/non_profit/non_profit/api.py
@@ -2019,7 +2019,7 @@ def get_event_details(event_name):
         return {"error": "Failed to retrieve event details"}
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_speaker_profiles(event_speakers):
     try:
         speakers_list = json.loads(event_speakers)


### PR DESCRIPTION
This pull request updates the event attendance workflow in the frontend to improve the user experience and prepare for future registration functionality. The main changes include a significant redesign of the `AttendEventModal`, better handling for guest users, and improved integration with the event detail page. Some backend API permissions have also been updated.

**Frontend Improvements:**

- **Redesigned Attendance Modal**
  - The `AttendEventModal` was visually overhauled to provide clearer instructions, confirmation steps, and a friendlier user interface. The modal now displays confirmation and reminder messages, and uses new iconography for a more engaging experience.
  - For guest users, the modal now conditionally displays a form to collect their name, email, and phone number before confirming attendance.
  - The modal's action buttons and error messages were improved for clarity and usability.

- **Integration with Event Detail Page**
  - The `AttendEventModal` is now imported and rendered in the `EventDetail.vue` page. [[1]](diffhunk://#diff-2cdd0c360e1274556494b58a680db83808ed92744921893a6450588d4ef5a464R235-R240) [[2]](diffhunk://#diff-2cdd0c360e1274556494b58a680db83808ed92744921893a6450588d4ef5a464R216)
  - The event registration button now opens the modal instead of showing a placeholder alert.
<img width="931" height="760" alt="image" src="https://github.com/user-attachments/assets/cb59d44c-7a48-4ad1-b880-602b32369a0f" />

**Backend API Permissions:**

- **Speaker Profiles API**
  - The `get_speaker_profiles` API endpoint is now accessible to guest users by setting `allow_guest=True` in the whitelist decorator.