### PR TITLE
Ft/vmms

### DIFF
--- a/frontend/src/pages/EventDetail.vue
+++ b/frontend/src/pages/EventDetail.vue
@@ -302,12 +302,12 @@ const eventDetail = createResource({
       (eventDetail.data?.event_access === "Private" ||
         eventDetail.data?.event_access === "Members Only")
     ) {
+      toast.error(
+        "This is a private event. Please log in  to view event details."
+      );
       setTimeout(() => {
-        toast.error(
-          "This is a private event. Please log in  to view event details."
-        );
+        router.push({ name: "Login" });
       }, 3000);
-      router.push({ name: "Login" });
     }
     speakerProfiles.reload();
   },

--- a/frontend/src/pages/Events.vue
+++ b/frontend/src/pages/Events.vue
@@ -17,6 +17,18 @@
       message="Failed to load Events"
     />
     <div>
+      <div class="flex justify-center mb-2">
+        <TextInput
+          type="search"
+          size="sm"
+          variant="outline"
+          placeholder="Search by event name, location, or date"
+          :disabled="false"
+          :modelValue="searchTerm"
+          @update:modelValue="(val) => (searchTerm = val)"
+        />
+      </div>
+
       <EventCard
         v-if="events.data && events.data.length > 0"
         v-for="event in events.data"
@@ -34,18 +46,34 @@
 </template>
 
 <script lang="ts" setup>
-import { onMounted, provide, ref } from "vue";
+import { onMounted, provide, ref, watch } from "vue";
 import EventCard from "../components/EventCard.vue";
 import { membershipStore } from "../stores/membership";
-import { createResource } from "frappe-ui";
+import { createResource, TextInput } from "frappe-ui";
 import ProgressSpinner from "../components/Common/ProgressSpinner.vue";
 import EmptyState from "../components/EmptyState.vue";
 import ErrorMessage from "frappe-ui/src/components/ErrorMessage/ErrorMessage.vue";
 
-const { events } = membershipStore();
+const searchTerm = ref("");
+
+const events = createResource({
+  url: "non_profit.non_profit.api.get_events",
+  auto: true,
+  cache: ["events"],
+  makeParams() {
+    return {
+      search: searchTerm.value,
+    };
+  },
+});
+
 const toggleEventView = ref(false);
 
 function toggleEventViews() {
   toggleEventView.value = !toggleEventView.value;
 }
+
+watch(searchTerm, () => {
+  events.reload();
+});
 </script>

--- a/non_profit/non_profit/api.py
+++ b/non_profit/non_profit/api.py
@@ -893,7 +893,8 @@ def check_app_permission():
 
 
 @frappe.whitelist(allow_guest=True)
-def get_events():
+def get_events(search=None):
+
     user_info = get_user_info()
 
     fields = [
@@ -908,6 +909,9 @@ def get_events():
         "route",
     ]
 
+    if search:
+        search_filters = {"venue": ["like", f"%{search}%"], "title": ["like", f"%{search}%"]}
+
     base_filters = {"start_date": [">=", datetime.now().date()], "is_published": 1}
 
     if user_info == "Guest":
@@ -918,7 +922,7 @@ def get_events():
     elif user_info.get("is_volunteer"):
         base_filters["event_access"] = ["in", ["Public", "Private"]]
 
-    events = frappe.get_all("FE Event", fields=fields, filters=base_filters)
+    events = frappe.get_all("FE Event", fields=fields, filters=base_filters, or_filters=search_filters if search else None, order_by="start_date asc, start_time asc")
 
     for event in events:
         event.short_description = (


### PR DESCRIPTION
This pull request adds search functionality to the Events page, allowing users to filter events by name or location. It also improves the user experience when accessing private events by redirecting unauthenticated users to the login page after displaying an error message. The most important changes are grouped below:

**Events Search Functionality:**

* Added a `TextInput` search box to `Events.vue` for filtering events by name, location. The search input is bound to the `searchTerm` variable and triggers a reload of events when updated. [[1]](diffhunk://#diff-ade9a1f8dc7acbc78953f1de0deb93f4de743bd409d4bc2366181945c8c83e8dR20-R31) [[2]](diffhunk://#diff-ade9a1f8dc7acbc78953f1de0deb93f4de743bd409d4bc2366181945c8c83e8dL37-R78)
* Updated the `get_events` API in `api.py` to accept an optional `search` parameter. When provided, it applies filters to match events by `venue` or `title` using a SQL `LIKE` query. [[1]](diffhunk://#diff-8d66a426671eab773446aec8f793d51b7dcb90b7b2135cad15c6fa0a8aba605bL896-R897) [[2]](diffhunk://#diff-8d66a426671eab773446aec8f793d51b7dcb90b7b2135cad15c6fa0a8aba605bR912-R914) [[3]](diffhunk://#diff-8d66a426671eab773446aec8f793d51b7dcb90b7b2135cad15c6fa0a8aba605bL921-R925)
* 
<img width="946" height="402" alt="image" src="https://github.com/user-attachments/assets/90adb3fe-540e-4cd7-9bce-6e3469fc66e5" />


<img width="946" height="295" alt="image" src="https://github.com/user-attachments/assets/ea266303-48a5-4792-93ea-e20c82ba9588" />

**User Experience Improvements:**

* Changed the behavior for private event access in `EventDetail.vue` so that after showing an error toast, the user is redirected to the login page after a short delay, rather than showing only the toast.

