### PR TITLE
Ft/vmms

### DIFF
--- a/non_profit/non_profit/api.py
+++ b/non_profit/non_profit/api.py
@@ -1489,7 +1489,7 @@ def get_current_membership():
 
     memberships = frappe.get_all(
         "Membership",
-        filters={"member": member.name},
+        filters={"member": member.name, "membership_status": "Active"},
         fields=[
             "name",
         ],

--- a/non_profit/non_profit/doctype/membership_type/membership_type.py
+++ b/non_profit/non_profit/doctype/membership_type/membership_type.py
@@ -9,10 +9,37 @@ from frappe.model.document import Document
 
 class MembershipType(Document):
 	def validate(self):
+		self.created_linked_item()
 		if self.linked_item:
-			is_stock_item = frappe.db.get_value("Item", self.linked_item, "is_stock_item")
+			is_stock_item = frappe.db.get_value(
+				"Item", self.linked_item, "is_stock_item"
+			)
 			if is_stock_item:
 				frappe.throw(_("The Linked Item should be a service item"))
 
+	def created_linked_item(self):
+		if not self.linked_item:
+			item = frappe.db.exists("Item", "Membership")
+
+			if item:
+				item = frappe.get_doc("Item", "Membership")
+
+			else:
+				item = frappe.get_doc(
+					{
+						"doctype": "Item",
+						"item_name": "Membership",
+						"item_code": "Membership",
+						"is_stock_item": 0,
+						"item_group": "Services",
+						"stock_uom": "Nos",
+					}
+				)
+
+				item.insert(ignore_permissions=True)
+				
+			self.linked_item = item.name
+
+
 def get_membership_type(razorpay_id):
-	return frappe.db.exists("Membership Type", {"razorpay_plan_id": razorpay_id})
+    return frappe.db.exists("Membership Type", {"razorpay_plan_id": razorpay_id})


### PR DESCRIPTION
This pull request introduces improvements to membership handling in the non-profit module, focusing on ensuring that only active memberships are considered and automating the creation of a linked service item for membership types.

Membership logic improvements:

* The `get_current_membership` function now filters memberships to only include those with a status of "Active", ensuring that inactive memberships are excluded from queries.

Membership type automation:

* In the `MembershipType` DocType (`membership_type.py`), a new method `created_linked_item` is added and invoked during validation to automatically create or assign a "Membership" service item if it doesn't already exist, and set it as the `linked_item`.
* The validation logic is updated to check that the linked item is a service item (not a stock item), maintaining data integrity for membership types.