### PR TITLE
feat(deployment_request): add TOR preview functionality and related fields to deployment requests

### DIFF
--- a/non_profit/non_profit/doctype/deployment_request_tool/deployment_request_tool.js
+++ b/non_profit/non_profit/doctype/deployment_request_tool/deployment_request_tool.js
@@ -69,6 +69,8 @@ frappe.ui.form.on("Deployment Request Tool", {
       return { filters };
     });
 
+    render_tor_preview(frm);
+
     frm
       .add_custom_button(__("Send Deployment Request"), () => {
         frm.trigger("deploy_employees");
@@ -139,6 +141,10 @@ frappe.ui.form.on("Deployment Request Tool", {
 
   expected_start_date: function (frm) {
     frm.trigger("get_employees");
+  },
+
+  terms_of_reference: function (frm) {
+    render_tor_preview(frm);
   },
 
   project(frm) {
@@ -516,19 +522,35 @@ frappe.ui.form.on("Deployment Request Tool", {
   },
 });
 
-$.each(
-  [
-    "companies",
-    "department",
-    "employment_type",
-    "designation",
-    "courses",
-    "skills",
-    "licences",
-  ],
-  function (i, fieldname) {
-    frappe.ui.form.on("Deployment Request Tool", fieldname, function (frm) {
-      frm.trigger("get_employees");
-    });
+async function render_tor_preview(frm) {
+  if (!frm.doc.terms_of_reference) {
+    frm.set_df_property("tor", "options", "");
+    frm.refresh_field("tor");
+    return;
   }
-);
+
+  const tor_name = frm.doc.terms_of_reference;
+  const doctype = "Personnel Terms of Reference";
+  const base_url = window.location.origin;
+
+  let pdf_url = `${base_url}/api/method/frappe.utils.print_format.download_pdf?doctype=${encodeURIComponent(
+    doctype
+  )}&name=${encodeURIComponent(tor_name)}`;
+
+  pdf_url += "&settings=%7B%7D&_lang=en";
+
+  const preview_html = `
+    <div style="text-align: right; margin-bottom: 10px;">
+      <a href="${pdf_url}" target="_blank" class="btn btn-primary btn-sm" style="margin-right: 5px;">View Full</a>
+      <a href="${pdf_url}" download class="btn btn-secondary btn-sm">Download</a>
+    </div>
+    <iframe src="${pdf_url}" style="width: 100%; height: 600px; border: 1px solid #ccc; border-radius: 8px;"></iframe>
+  `;
+
+  frm.set_df_property("tor", "options", preview_html);
+  if (frm.doc.tor_url !== pdf_url) {
+    frm.doc.tor_url = pdf_url;
+    frm.save();
+  }
+  frm.refresh_field("tor");
+}

--- a/non_profit/non_profit/doctype/deployment_request_tool/deployment_request_tool.json
+++ b/non_profit/non_profit/doctype/deployment_request_tool/deployment_request_tool.json
@@ -21,6 +21,8 @@
   "require_contract_before_deployment",
   "terms_section",
   "terms_of_reference",
+  "tor_url",
+  "tor",
   "section_break_rmvn",
   "notes",
   "quick_filters_section",
@@ -225,6 +227,7 @@
    "options": "Volunteer Skill"
   },
   {
+   "collapsible": 1,
    "fieldname": "terms_section",
    "fieldtype": "Section Break",
    "label": "Terms"
@@ -292,6 +295,18 @@
    "fieldtype": "Table MultiSelect",
    "label": "Branch",
    "options": "Company Item"
+  },
+  {
+   "fieldname": "tor",
+   "fieldtype": "HTML",
+   "label": "TOR"
+  },
+  {
+   "fieldname": "tor_url",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "TOR Url",
+   "options": "URL"
   }
  ],
  "grid_page_length": 50,
@@ -333,7 +348,7 @@
    "link_fieldname": "personnel_deployment_request"
   }
  ],
- "modified": "2025-10-24 13:34:00.569418",
+ "modified": "2025-10-24 17:13:09.909785",
  "modified_by": "Administrator",
  "module": "Non Profit",
  "name": "Deployment Request Tool",

--- a/non_profit/non_profit/doctype/deployment_request_tool/deployment_request_tool.py
+++ b/non_profit/non_profit/doctype/deployment_request_tool/deployment_request_tool.py
@@ -83,9 +83,6 @@ class DeploymentRequestTool(Document):
                     "notes": self.notes,
                     "require_contract_before_deployment": self.require_contract_before_deployment,
                     "terms_of_reference": self.terms_of_reference,
-                    "expense_approver": self.expense_approver,
-                    "advance_approver": self.advance_approver,
-                    "deployment_approver": self.deployment_approver,
                 }
 
                 if self.get("deployment_request_term_template"):

--- a/non_profit/non_profit/doctype/personnel_deployment_request/personnel_deployment_request.js
+++ b/non_profit/non_profit/doctype/personnel_deployment_request/personnel_deployment_request.js
@@ -3,30 +3,6 @@
 
 frappe.ui.form.on("Personnel Deployment Request", {
   refresh(frm) {
-    frappe.call({
-      method: "non_profit.non_profit.utils.get_expense_and_advance_approvers",
-      callback: function (r) {
-        if (r.message) {
-          frm.allowed_approvers = r.message;
-
-          frm.set_query("expense_approver", function () {
-            return {
-              filters: {
-                name: ["in", frm.allowed_approvers],
-              },
-            };
-          });
-
-          frm.set_query("advance_approver", function () {
-            return {
-              filters: {
-                name: ["in", frm.allowed_approvers],
-              },
-            };
-          });
-        }
-      },
-    });
     if (!frm.is_new() && frm.doc.require_contract_before_deployment) {
       frappe.db.get_value(
         "Contract",
@@ -58,7 +34,14 @@ frappe.ui.form.on("Personnel Deployment Request", {
         }
       );
     }
+
+    render_tor_preview(frm);
   },
+
+  terms_of_reference: function (frm) {
+    render_tor_preview(frm);
+  },
+
   task(frm) {
     if (!frm.doc.task) return;
 
@@ -94,9 +77,7 @@ frappe.ui.form.on("Personnel Deployment Request", {
         "expected_start_date",
         "expected_end_date",
         "notes",
-        "expense_approver",
-        "advance_approver",
-        "project_manager",
+        "terms_of_reference",
       ])
       .then((r) => {
         if (r && r.message) {
@@ -106,12 +87,8 @@ frappe.ui.form.on("Personnel Deployment Request", {
           if (r.message.expected_end_date)
             frm.set_value("expected_end_date", r.message.expected_end_date);
           if (r.message.notes) frm.set_value("notes", r.message.notes);
-          if (r.message.expense_approver)
-            frm.set_value("expense_approver", r.message.expense_approver);
-          if (r.message.advance_approver)
-            frm.set_value("advance_approver", r.message.advance_approver);
-          if (r.message.project_manager)
-            frm.set_value("deployment_approver", r.message.project_manager);
+          if (r.message.terms_of_reference)
+            frm.set_value("terms_of_reference", r.message.terms_of_reference);
         }
       });
     frm.trigger("get_employees");
@@ -122,11 +99,8 @@ frappe.ui.form.on("Personnel Deployment Request", {
     frappe.db
       .get_value("Deployment Request Tool", frm.doc.deployment, [
         "project",
-        "expense_approver",
-        "advance_approver",
-        "deployment_approver",
         "terms_of_reference",
-        "require_contract_before_deployment",
+        "tor_url",
         "expected_start_date",
         "expected_end_date",
         "notes",
@@ -134,19 +108,10 @@ frappe.ui.form.on("Personnel Deployment Request", {
       .then((r) => {
         if (r && r.message) {
           if (r.message.project) frm.set_value("project", r.message.project);
-          if (r.message.expense_approver)
-            frm.set_value("expense_approver", r.message.expense_approver);
-          if (r.message.advance_approver)
-            frm.set_value("advance_approver", r.message.advance_approver);
-          if (r.message.deployment_approver)
-            frm.set_value("deployment_approver", r.message.deployment_approver);
+          if (r.message.tor_url) frm.set_value("tor_url", r.message.tor_url);
           if (r.message.terms_of_reference)
             frm.set_value("terms_of_reference", r.message.terms_of_reference);
-          if (r.message.require_contract_before_deployment !== undefined)
-            frm.set_value(
-              "require_contract_before_deployment",
-              r.message.require_contract_before_deployment
-            );
+
           if (r.message.expected_start_date)
             frm.set_value("expected_start_date", r.message.expected_start_date);
           if (r.message.expected_end_date)
@@ -166,3 +131,36 @@ frappe.ui.form.on("Personnel Deployment Request", {
     });
   },
 });
+
+async function render_tor_preview(frm) {
+  if (!frm.doc.terms_of_reference) {
+    frm.set_df_property("tor", "options", "");
+    frm.refresh_field("tor");
+    return;
+  }
+
+  const tor_name = frm.doc.terms_of_reference;
+  const doctype = "Personnel Terms of Reference";
+  const base_url = window.location.origin;
+
+  let pdf_url = `${base_url}/api/method/frappe.utils.print_format.download_pdf?doctype=${encodeURIComponent(
+    doctype
+  )}&name=${encodeURIComponent(tor_name)}`;
+
+  pdf_url += "&settings=%7B%7D&_lang=en";
+
+  const preview_html = `
+    <div style="text-align: right; margin-bottom: 10px;">
+      <a href="${pdf_url}" target="_blank" class="btn btn-primary btn-sm" style="margin-right: 5px;">View Full</a>
+      <a href="${pdf_url}" download class="btn btn-secondary btn-sm">Download</a>
+    </div>
+    <iframe src="${pdf_url}" style="width: 100%; height: 600px; border: 1px solid #ccc; border-radius: 8px;"></iframe>
+  `;
+
+  frm.set_df_property("tor", "options", preview_html);
+  if (frm.doc.tor_url !== pdf_url) {
+    frm.doc.tor_url = pdf_url;
+    frm.save();
+  }
+  frm.refresh_field("tor");
+}

--- a/non_profit/non_profit/doctype/personnel_deployment_request/personnel_deployment_request.json
+++ b/non_profit/non_profit/doctype/personnel_deployment_request/personnel_deployment_request.json
@@ -26,6 +26,8 @@
   "notes",
   "terms_section",
   "terms_of_reference",
+  "tor_url",
+  "tor",
   "amended_from"
  ],
  "fields": [
@@ -131,6 +133,7 @@
    "label": "Notes"
   },
   {
+   "collapsible": 1,
    "fieldname": "terms_section",
    "fieldtype": "Section Break",
    "label": "Terms"
@@ -177,6 +180,18 @@
    "fieldtype": "Tab Break",
    "label": "Details",
    "show_dashboard": 1
+  },
+  {
+   "fieldname": "tor",
+   "fieldtype": "HTML",
+   "label": "TOR"
+  },
+  {
+   "fieldname": "tor_url",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "TOR Url",
+   "options": "URL"
   }
  ],
  "grid_page_length": 50,
@@ -215,7 +230,7 @@
    "link_fieldname": "personnel_deployment_assignment"
   }
  ],
- "modified": "2025-10-24 13:33:03.047476",
+ "modified": "2025-10-24 17:13:25.382968",
  "modified_by": "Administrator",
  "module": "Non Profit",
  "name": "Personnel Deployment Request",

--- a/non_profit/non_profit/doctype/personnel_deployment_request/personnel_deployment_request.py
+++ b/non_profit/non_profit/doctype/personnel_deployment_request/personnel_deployment_request.py
@@ -11,16 +11,6 @@ class PersonnelDeploymentRequest(Document):
         if not self.date:
             self.date = today()
 
-    def before_submit(self):
-        if self.deployment:
-            deployment = frappe.get_doc("Deployment Request Tool", self.deployment)
-            if not self.expense_approver and deployment.expense_approver:
-                self.expense_approver = deployment.expense_approver
-            if not self.advance_approver and deployment.advance_approver:
-                self.advance_approver = deployment.advance_approver
-            if not self.deployment_approver and deployment.deployment_approver:
-                self.deployment_approver = deployment.deployment_approver
-
     def before_update_after_submit(self):
         self.number_of_volunteers_required()
 


### PR DESCRIPTION
Add TOR preview with embedded PDF viewer and download options

Enhances Terms of Reference (TOR) handling by:
- Embedding a PDF viewer directly within deployment requests
- Adding view and download buttons for quick document access
- Removing redundant approver-related fields and logic
- Making the terms section collapsible for a cleaner and more organized UI

Improves user experience by allowing immediate in-form preview of TOR documents without navigating away from the deployment request.