### PR TITLE
Ft/member

### DIFF
--- a/frontend/src/components/MemberPlan.vue
+++ b/frontend/src/components/MemberPlan.vue
@@ -72,8 +72,13 @@
                 theme="red"
                 size="sm"
                 class="rounded-lg px-5 py-2"
+                :loading="certificate.loading"
                 @click="
-                  openRenewDialog(membership.membership_status, membership.name)
+                  openRenewDialog(
+                    membership.membership_status,
+                    membership.name,
+                    membership.membership_type
+                  )
                 "
               >
                 {{
@@ -84,6 +89,7 @@
               </Button>
             </div>
           </div>
+          <ErrorMessage :message="certificate.error" class="text-center mt-2" />
         </div>
       </div>
 
@@ -182,6 +188,7 @@ import { ref } from "vue";
 import { RouterLink } from "vue-router";
 import { usersStore } from "../stores/user";
 import { isValidPhone } from "../utils/volunteer";
+import { on } from "superagent";
 
 const { roleResource } = usersStore();
 
@@ -201,6 +208,7 @@ interface Membership {
   type_details?: Record<string, any>;
 }
 
+const membershipTypeCert = ref("");
 const membershipList = createResource<Membership[]>({
   url: "non_profit.non_profit.api.get_current_membership",
   auto: true,
@@ -240,9 +248,25 @@ function formatDate(dateStr?: string): string {
   });
 }
 
-function openRenewDialog(membershipStatus?: string, membershipId?: string) {
+const certificate = createResource({
+  url: "non_profit.non_profit.api.membership_certificate_template",
+  makeParams() {
+    return {
+      membership_type: membershipTypeCert.value,
+    };
+  },
+});
+
+function openRenewDialog(
+  membershipStatus?: string,
+  membershipId?: string,
+  membershipType?: string
+) {
   if (membershipStatus === "Active") {
-    // TODO: Implement certificate printing logic here
+    membershipTypeCert.value = membershipType || "";
+
+    getCertificate(membershipId);
+
     return;
   }
 
@@ -251,6 +275,20 @@ function openRenewDialog(membershipStatus?: string, membershipId?: string) {
     errorMessage.value = "";
     payNow.value = true;
   }
+}
+
+function getCertificate(membershipId?: string) {
+  certificate.submit(
+    {},
+    {
+      onSuccess() {
+        window.open(
+          `/api/method/frappe.utils.print_format.download_pdf?doctype=Membership&name=${membershipId}&format=${membershipTypeCert.value}`,
+          "_blank"
+        );
+      },
+    }
+  );
 }
 
 function payMembership() {
@@ -276,4 +314,14 @@ function payMembership() {
     phone_number: phoneNumber.value,
   });
 }
+
+const downloadCertificate = createResource({
+  url: "/api/method/frappe.utils.print_format.download_pdf",
+  makeParams() {
+    return {
+      doctype: "Membership",
+      name: selectedMembershipId.value,
+    };
+  },
+});
 </script>

--- a/non_profit/non_profit/api.py
+++ b/non_profit/non_profit/api.py
@@ -2074,3 +2074,29 @@ def handle_ticket_payment(phone, event_name, ticket_name, email, first_name, las
             "success": False,
             "message": "Error occurred while processing ticket. Please try again.",
         }
+
+
+@frappe.whitelist()
+def membership_certificate_template(membership_type: str) -> str:
+
+    error_message = "An unexpected error occurred"
+    if not membership_type:
+        frappe.throw(error_message)
+
+    try:
+        membership_template = frappe.db.get_value(
+            "Print Format",
+            {"name": membership_type, "doc_type": "Membership"},
+            "name",
+            as_dict=True,
+        )
+
+        if not membership_template:
+            frappe.throw(error_message)
+    except Exception as e:
+        frappe.log_error(
+            frappe.get_traceback(), "Membership Certificate Template Error"
+        )
+        frappe.throw(error_message)
+
+    return membership_template.name


### PR DESCRIPTION
This pull request introduces enhancements to the membership certificate printing workflow in the `MemberPlan.vue` component and adds a new backend API endpoint for certificate template retrieval. The main changes focus on enabling users to download membership certificates based on membership type, improving error handling, and updating the UI to reflect the certificate loading state and errors.

### Frontend improvements for certificate printing

* Added a loading state to the certificate download button and displays error messages using the new `certificate` resource, improving user feedback during certificate generation. [[1]](diffhunk://#diff-a8cc944fe913bf7103d9126f2c2d1d6afdc1d537886c1203a0541aabccb0fe9eR75-R81) [[2]](diffhunk://#diff-a8cc944fe913bf7103d9126f2c2d1d6afdc1d537886c1203a0541aabccb0fe9eR92)
* Refactored the `openRenewDialog` function to accept `membership_type` and trigger certificate retrieval and download via the new `getCertificate` function. [[1]](diffhunk://#diff-a8cc944fe913bf7103d9126f2c2d1d6afdc1d537886c1203a0541aabccb0fe9eL243-R269) [[2]](diffhunk://#diff-a8cc944fe913bf7103d9126f2c2d1d6afdc1d537886c1203a0541aabccb0fe9eR280-R293)
* Introduced a reactive variable `membershipTypeCert` to store the selected membership type for certificate printing.
* Added a new `createResource` for certificate template fetching and download, supporting API-driven certificate generation. [[1]](diffhunk://#diff-a8cc944fe913bf7103d9126f2c2d1d6afdc1d537886c1203a0541aabccb0fe9eL243-R269) [[2]](diffhunk://#diff-a8cc944fe913bf7103d9126f2c2d1d6afdc1d537886c1203a0541aabccb0fe9eR317-R326)

### Backend API addition

* Implemented a new whitelisted API method `membership_certificate_template` in `api.py` to securely fetch the print format template name for a given membership type, with comprehensive error handling and logging.