### PR TITLE
fix(non-profit): update link type to Workspace Sidebar

### DIFF
--- a/non_profit/desktop_icon/non_profit.json
+++ b/non_profit/desktop_icon/non_profit.json
@@ -9,12 +9,13 @@
  "idx": 0,
  "label": "Non Profit",
  "link_to": "Non Profit",
- "link_type": "Workspace",
+ "link_type": "Workspace Sidebar",
  "logo_url": "/assets/non_profit/non-profit.png",
- "modified": "2026-01-08 13:14:36.210947",
+ "modified": "2026-01-26 14:37:10.135583",
  "modified_by": "Administrator",
  "name": "Non Profit",
  "owner": "Administrator",
+ "restrict_removal": 0,
  "roles": [],
  "standard": 1
 }


### PR DESCRIPTION
Update Non Profit desktop icon metadata to ensure the app appears in the workspace sidebar.

Key changes:
- Set link_type to "Workspace Sidebar".
- Added restrict_removal flag (0) to control removal behavior.
- Updated modification timestamp to reflect the metadata change.