### PR TITLE
feat(donor): enhance Donor with customer creation and UI improvements

### DIFF
--- a/non_profit/non_profit/doctype/donor/donor.js
+++ b/non_profit/non_profit/doctype/donor/donor.js
@@ -1,17 +1,32 @@
 // Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Donor', {
-	refresh: function(frm) {
-		frappe.dynamic_link = {doc: frm.doc, fieldname: 'name', doctype: 'Donor'};
+frappe.ui.form.on("Donor", {
+  refresh: function (frm) {
+    frappe.dynamic_link = { doc: frm.doc, fieldname: "name", doctype: "Donor" };
 
-		frm.toggle_display(['address_html','contact_html'], !frm.doc.__islocal);
+    frm.toggle_display(["address_html", "contact_html"], !frm.doc.__islocal);
+    frm.toggle_display(
+      "create_customer",
+      !frm.doc.customer && !frm.doc.__islocal,
+    );
 
-		if(!frm.doc.__islocal) {
-			frappe.contacts.render_address_and_contact(frm);
-		} else {
-			frappe.contacts.clear_address_and_contact(frm);
-		}
+    if (!frm.doc.__islocal) {
+      frappe.contacts.render_address_and_contact(frm);
+    } else {
+      frappe.contacts.clear_address_and_contact(frm);
+    }
+  },
 
-	}
+  create_customer: (frm) => {
+    frm.call({
+      method: "create_customer",
+      doc: frm.doc,
+      callback: function (r) {
+        if (r.message) {
+          frappe.msgprint("Customer " + r.message + " created.");
+        }
+      },
+    });
+  },
 });

--- a/non_profit/non_profit/doctype/donor/donor.json
+++ b/non_profit/non_profit/doctype/donor/donor.json
@@ -8,33 +8,64 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "primary_details_section",
   "donor_name",
   "email",
   "phone_number",
-  "id_number",
   "salutation",
   "column_break_5",
   "donor_type",
-  "charter",
+  "id_number",
+  "image",
+  "customer",
+  "create_customer",
+  "donor_info_section",
   "birthday_date",
   "date_registered",
+  "column_break_15",
   "is_a_frequent_donor",
-  "image",
+  "charter",
+  "accounting_dimensions_section",
+  "cost_center",
+  "dimension_col_break",
+  "address_and_contact_tab",
   "address_contacts",
   "address_html",
   "column_break_9",
   "contact_html",
-  "accounting_dimensions_section",
-  "cost_center",
-  "dimension_col_break"
+  "connections_tab"
  ],
  "fields": [
+  {
+   "fieldname": "primary_details_section",
+   "fieldtype": "Section Break",
+   "label": "Primary Details"
+  },
   {
    "fieldname": "donor_name",
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Donor Name",
    "reqd": 1
+  },
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Email",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "phone_number",
+   "fieldtype": "Data",
+   "label": "Phone Number"
+  },
+  {
+   "fieldname": "salutation",
+   "fieldtype": "Link",
+   "label": "Salutation",
+   "options": "Salutation"
   },
   {
    "fieldname": "column_break_5",
@@ -49,12 +80,16 @@
    "reqd": 1
   },
   {
-   "fieldname": "email",
+   "description": "Link this donor to a Customer record for accounting purposes.",
+   "fieldname": "customer",
+   "fieldtype": "Link",
+   "label": "Linked Customer",
+   "options": "Customer"
+  },
+  {
+   "fieldname": "id_number",
    "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Email",
-   "reqd": 1,
-   "unique": 1
+   "label": "ID Number"
   },
   {
    "fieldname": "image",
@@ -63,6 +98,37 @@
    "label": "Image",
    "no_copy": 1,
    "print_hide": 1
+  },
+  {
+   "fieldname": "donor_info_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_a_frequent_donor",
+   "fieldtype": "Check",
+   "label": "Is a frequent donor?"
+  },
+  {
+   "fieldname": "birthday_date",
+   "fieldtype": "Date",
+   "label": "Birthday Date"
+  },
+  {
+   "fieldname": "date_registered",
+   "fieldtype": "Date",
+   "label": "Date Registered"
+  },
+  {
+   "fieldname": "column_break_15",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "charter",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Charter",
+   "options": "Funding Pool"
   },
   {
    "depends_on": "eval:!doc.__islocal;",
@@ -102,43 +168,20 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "0",
-   "fieldname": "is_a_frequent_donor",
-   "fieldtype": "Check",
-   "label": "Is a frequent donor?"
+   "fieldname": "create_customer",
+   "fieldtype": "Button",
+   "label": "Create Customer"
   },
   {
-   "fieldname": "phone_number",
-   "fieldtype": "Data",
-   "label": "Phone Number"
+   "fieldname": "address_and_contact_tab",
+   "fieldtype": "Tab Break",
+   "label": "Address and Contact"
   },
   {
-   "fieldname": "birthday_date",
-   "fieldtype": "Date",
-   "label": "Birthday Date"
-  },
-  {
-   "fieldname": "id_number",
-   "fieldtype": "Data",
-   "label": "ID Number"
-  },
-  {
-   "fieldname": "salutation",
-   "fieldtype": "Link",
-   "label": "Salutation",
-   "options": "Salutation"
-  },
-  {
-   "fieldname": "date_registered",
-   "fieldtype": "Date",
-   "label": "Date Registered"
-  },
-  {
-   "fieldname": "charter",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Charter",
-   "options": "Funding Pool"
+   "fieldname": "connections_tab",
+   "fieldtype": "Tab Break",
+   "label": "Connections",
+   "show_dashboard": 1
   }
  ],
  "image_field": "image",
@@ -148,7 +191,7 @@
    "link_fieldname": "donor"
   }
  ],
- "modified": "2025-05-17 14:50:15.607245",
+ "modified": "2026-01-27 11:31:51.998451",
  "modified_by": "Administrator",
  "module": "Non Profit",
  "name": "Donor",

--- a/non_profit/non_profit/doctype/donor/donor.py
+++ b/non_profit/non_profit/doctype/donor/donor.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-
+import frappe
 from frappe.contacts.address_and_contact import load_address_and_contact
 from frappe.model.document import Document
 
@@ -15,3 +15,31 @@ class Donor(Document):
 		from frappe.utils import validate_email_address
 		if self.email:
 			validate_email_address(self.email.strip(), True)
+
+	def after_insert(self):
+		settings = frappe.get_doc("Changemakers Settings")
+
+		if settings.generate_customer_when_donor_is_created:
+			self.create_customer()
+
+	@frappe.whitelist()
+	def create_customer(self) :
+		if self.customer:
+			return
+		
+		if not frappe.db.exists("Customer Group", "Beneficiary"):
+			customer_group = frappe.new_doc("Customer Group")
+			customer_group.customer_group_name = "Beneficiary"
+			customer_group.flags.ignore_permissions = True
+			customer_group.insert()
+
+		customer = frappe.new_doc("Customer")
+		customer.customer_name = self.donor_name
+		customer.customer_type = "Individual"
+		customer.customer_group = "Beneficiary"
+
+		customer.flags.ignore_permissions = True
+		customer.insert()
+		self.customer = customer.name
+		self.save()
+		return customer.name


### PR DESCRIPTION
Add server-side logic and client UI to create and link a Customer from a Donor for accounting purposes.

Key changes:
- Implemented customer creation from Donor, with optional
  auto-create on insert based on settings.
- Ensure "Beneficiary" customer group exists before creating customers.
- Store linked Customer reference on the Donor record.
- Added contact fields to Donor (email, phone, salutation, image).
- Reorganized Donor form layout with improved sections and tabs.
- Added "Create Customer" button with conditional visibility.
- Improved address and contact rendering and clearing logic.