### PR TITLE
Fix/frappe dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ build-backend = "flit_core.buildapi"
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"
 
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0"
+
 [tool.ruff]
 line-length = 110
 target-version = "py310"


### PR DESCRIPTION
This pull request adds a new section to the `pyproject.toml` file to specify a dependency on the `frappe` package version 15.0.0 or higher.

- Dependency management:
  * Added a `[tool.bench.frappe-dependencies]` section to `pyproject.toml` with `frappe >=15.0.0` to explicitly declare the required version of the `frappe` framework.