### PR TITLE
fix(dependencies): add frappe dependency for bench tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ build-backend = "flit_core.buildapi"
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"
 
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0"
+
 [tool.ruff]
 line-length = 110
 target-version = "py310"


### PR DESCRIPTION
This pull request introduces a new section for managing Frappe dependencies in the `pyproject.toml` file. This change is intended to explicitly specify the required version of the `frappe` package for the project.

Dependency management:

* Added a `[tool.bench.frappe-dependencies]` section to `pyproject.toml` with a minimum required version of `frappe` set to `>=15.0.0`.